### PR TITLE
Surface-brightness Maps

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.2dev
 commit = False
 tag = False
 tag_name = {new_version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
-0.0.1dev
+
+0.1.1dev
 --------
+
+ - Include `PowerExp` 1D model
+ - Allow the surface-brightness used during the model construction to be
+   defined separately from the binned surface-brightness data.  This is
+   useful for modeling the stellar kinematics.
+ - Allow the surface-brightness masks to be patched by a Gaussian
+   smoothing algorithm to fill surface-brightness holes.
+
+0.1.0
+-----
 
  - Initial version
  - Add beam-smearing

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 
-0.1.1dev
+0.1.2dev
 --------
 
  - Include `PowerExp` 1D model

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,9 +22,9 @@ copyright = '2021, Brian DiGiorgio, Kyle Westfall'
 author = 'Brian DiGiorgio, Kyle Westfall'
 
 # The short X.Y version.
-version = '0.1.1'
+version = '0.1.2dev'
 # The full version, including alpha/beta/rc tags
-release = '0.1.1'
+release = '0.1.2dev'
 
 
 # -- General configuration ---------------------------------------------------

--- a/nirvana/__init__.py
+++ b/nirvana/__init__.py
@@ -1,5 +1,5 @@
 
-__version__ = '0.1.1'
+__version__ = '0.1.2dev'
 __license__ = 'BSD3'
 __author__ = 'Brian DiGiorgio'
 __maintainer__ = 'Brian DiGiorgio'

--- a/nirvana/data/kinematics.py
+++ b/nirvana/data/kinematics.py
@@ -137,6 +137,15 @@ class Kinematics(FitArgs):
             The on-sky Cartesian :math:`y` coordinates of *each*
             element in the data grid. See the description of
             ``grid_x``.
+        grid_sb (`numpy.array`_, optional):
+            The relative surface brightness of the kinematic tracer over the
+            full coordinate grid.  If None, this is either assumed to be unity
+            or set by the provided ``sb``.  When fitting the data with, e.g., 
+            :class:`~nirvana.model.axisym.AxisymmetricDisk` via the ``sb_wgt``
+            parameter in its fitting method, this will be the weighting used.
+            The relevance of this array is to enable the weighting used in
+            constructing the model velocity field to be *unbinned* for otherwise
+            binned kinematic data.
         grid_wcs (`astropy.wcs.WCS`_, optional):
             World coordinate system for the on-sky grid. Currently, this is
             only used for output files.
@@ -164,8 +173,8 @@ class Kinematics(FitArgs):
     def __init__(self, vel, vel_ivar=None, vel_mask=None, vel_covar=None, x=None, y=None, sb=None,
                  sb_ivar=None, sb_mask=None, sb_covar=None, sb_anr=None, sig=None, sig_ivar=None,
                  sig_mask=None, sig_covar=None, sig_corr=None, psf_name=None, psf=None,
-                 aperture=None, binid=None, grid_x=None, grid_y=None, grid_wcs=None, reff=None,
-                 fwhm=None, bordermask=None, image=None, phot_inc=None, maxr=None,
+                 aperture=None, binid=None, grid_x=None, grid_y=None, grid_sb=None, grid_wcs=None,
+                 reff=None, fwhm=None, bordermask=None, image=None, phot_inc=None, maxr=None,
                  positive_definite=False, quiet=False):
 
         # Check shape of input arrays
@@ -179,7 +188,7 @@ class Kinematics(FitArgs):
         if vel.shape[1] != self.nimg:
             raise ValueError('Input arrays to Kinematics must be square.')
         for a in [vel_ivar, vel_mask, x, y, sb, sb_ivar, sb_mask, sig, sig_ivar, sig_mask,
-                  sig_corr, psf, aperture, binid, grid_x, grid_y]:
+                  sig_corr, psf, aperture, binid, grid_x, grid_y, grid_sb]:
             if a is not None and a.shape != vel.shape:
                 raise ValueError('All arrays provided to Kinematics must have the same shape.')
         if (x is None and y is not None) or (x is not None and y is None):
@@ -239,6 +248,11 @@ class Kinematics(FitArgs):
                      'sig_ivar', 'sig_mask', 'sig_corr', 'bordermask','sb_anr']:
             if getattr(self, attr) is not None:
                 setattr(self, attr, getattr(self, attr).ravel()[self.bin_indx])
+
+        # Set the surface-brightness grid.  This needs to be after the
+        # unraveling of the attributes done in the lines above so that I can use
+        # self.remap in the case that grid_sb is not provided directly.
+        self.grid_sb = self.remap('sb').filled(0.0) if grid_sb is None else grid_sb
 
         # Calculate the square of the astrophysical velocity
         # dispersion. This is just the square of the velocity

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -661,9 +661,8 @@ class AxisymmetricDisk:
         self.kin = kin
         self.x = self.kin.grid_x
         self.y = self.kin.grid_y
-        # TODO: This should be changed for binned data. I.e., we should be
-        # weighting by the *unbinned* surface-brightness map.
-        self.sb = self.kin.remap('sb').filled(0.0) if sb_wgt else None
+#        self.sb = self.kin.remap('sb').filled(0.0) if sb_wgt else None
+        self.sb = self.kin.grid_sb if sb_wgt else None
         self.beam_fft = self.kin.beam_fft
         self.vel_gpm = np.logical_not(self.kin.vel_mask)
         self.sig_gpm = None if self.dc is None else np.logical_not(self.kin.sig_mask)

--- a/nirvana/models/oned.py
+++ b/nirvana/models/oned.py
@@ -689,6 +689,105 @@ class ExpBase(Func1D):
         return -self.sample(x)/self.par[1]
 
 
+class PowerExp(Func1D):
+    r"""
+    Instantiates a function combining a power-law and an exponential.
+
+    Functional form is:
+
+    .. math::
+
+        f(x) = f_0 \frac{e}{h \gamma}^{\gamma} x^{\gamma} e^{-x/h}
+
+    where :math:`\gamma \geq 0` and :math:`h > 0`. Parameter vectors are
+    ordered: :math:`f_0, h, \gamma`. The maximum value of the function,
+    :math:`f_0`, occurs at :math:`x = h \gamma`.
+
+    Args:
+        par (array-like, optional):
+            The two model parameters. If None, set by
+            :func:`guess_par`.
+        lb (array-like, optional):
+            Lower bounds for the model parameters. If None, set by
+            :func:`par_bounds`.
+        ub (:obj:`float`, optional):
+            Upper bounds for the model parameters. If None, set by
+            :func:`par_bounds`.
+    """
+    def __init__(self, par=None, lb=None, ub=None):
+        super().__init__(self.guess_par() if par is None else par)
+        if lb is not None and len(lb) != self.np:
+            raise ValueError('Number of lower bounds does not match the number of parameters.')
+        if lb is not None and len(ub) != self.np:
+            raise ValueError('Number of upper bounds does not match the number of parameters.')
+        _lb, _ub = self.par_bounds()
+        self.lb = _lb if lb is None else np.atleast_1d(lb)
+        self.ub = _ub if ub is None else np.atleast_1d(ub)
+
+    @staticmethod
+    def guess_par():
+        """Return default guess parameters."""
+        return np.array([100., 10., 1.])
+
+    @staticmethod
+    def par_names(short=False):
+        """
+        Return a list of strings with the parameter names.
+        """
+        if short:
+            return ['a', 'h', 'g']
+        return ['Amplitude', 'e-folding length', 'Power index']
+
+    @staticmethod
+    def par_bounds():
+        """
+        Return default parameter boundaries.
+
+        Returns:
+            :obj:`tuple`: Two `numpy.ndarray`_ objects with,
+            respectively, the lower and upper bounds for the
+            parameters.
+        """
+        return np.array([0., 1e-3, 0.]), np.array([500., 100., 5.])
+
+    def sample(self, x, par=None, check=False):
+        """
+        Sample the function.
+
+        Args:
+            x (array-like):
+                Locations at which to sample the function.
+            par (array-like, optional):
+                The function parameters. If None, the current values
+                of :attr:`par` are used. Must have a length of
+                :attr:`np`.
+            check (:obj:`bool`, optional):
+                Ignored. Only included for a uniform interface with
+                other subclasses of :class:`Func1D`.
+
+        Returns:
+            `numpy.ndarray`_: Function evaluated at each ``x`` value.
+        """
+        if par is not None:
+            self._set_par(par)
+        _x = np.asarray(x)
+        c = (np.e / self.par[1] / self.par[2])**self.par[2]
+        return c * self.par[0] * np.exp(-_x/self.par[1]) * _x**self.par[2]
+
+    def ddx(self, x, par=None, check=False):
+        """
+        Sample the derivative of the function. See :func:`sample` for
+        the argument descriptions.
+        """
+        if par is not None:
+            self._set_par(par)
+        c = (np.e / self.par[1] / self.par[2])**self.par[2]
+        indx = np.absolute(x) > 1e-10
+        deriv = np.zeros(x.size, dtype=float)
+        deriv[indx] = self.sample(x[indx]) * (self.par[2]/x[indx] - 1/self.par[1]) 
+        return deriv
+
+
 class Const(Func1D):
     r"""
     A function that always returns the same constant.

--- a/nirvana/scripts/manga_axisym.py
+++ b/nirvana/scripts/manga_axisym.py
@@ -88,6 +88,13 @@ def parse_args(options=None):
                              '(ignored if dispersion not being fit).')
     parser.add_argument('--min_unmasked', default=None, type=int,
                         help='Minimum number of unmasked spaxels required to continue fit.')
+    parser.add_argument('--max_flux', default=None, type=float,
+                        help='Maximum flux to include in the surface-brightness weighting.')
+    parser.add_argument('--sb_fill_sig', default=None, type=float,
+                        help='Fill the surface-brightness map used for constructing the '
+                             'beam-smeared model using an iterative Gaussian smoothing '
+                             'operation.  This parameter both turns this on and sets the size of '
+                             'the circular Gaussian smoothing kernel in spaxels.')
     parser.add_argument('--coherent', default=False, action='store_true',
                         help='After the initial rejection of S/N and error limits, find the '
                              'largest coherent region of adjacent spaxels and only fit that '
@@ -122,6 +129,8 @@ def main(args):
     #  - Set the output root name
     oroot = f'nirvana-manga-axisym-{args.plate}-{args.ifu}-{args.tracer}'
 
+    flux_bound = (None, args.max_flux)
+
     #---------------------------------------------------------------------------
     # Read the data to fit
     if args.tracer == 'Gas':
@@ -131,7 +140,8 @@ def main(args):
                                                      analysis_path=args.analysis,
                                                      maps_path=args.root,
                                                      ignore_psf=not args.smear, covar=args.covar,
-                                                     positive_definite=True)
+                                                     positive_definite=True, flux_bound=flux_bound,
+                                                     sb_fill=args.sb_fill_sig)
     elif args.tracer == 'Stars':
         kin = manga.MaNGAStellarKinematics.from_plateifu(args.plate, args.ifu,
                                                          daptype=args.daptype, dr=args.dr,
@@ -140,7 +150,8 @@ def main(args):
                                                          analysis_path=args.analysis,
                                                          maps_path=args.root,
                                                          ignore_psf=not args.smear,
-                                                         covar=args.covar, positive_definite=True)
+                                                         covar=args.covar, positive_definite=True,
+                                                         sb_fill=args.sb_fill_sig)
     else:
         # NOTE: Should never get here given the check above.
         raise ValueError(f'Unknown tracer: {args.tracer}')

--- a/nirvana/tests/test_manga.py
+++ b/nirvana/tests/test_manga.py
@@ -151,7 +151,16 @@ def test_files():
     assert files[0].split('-')[0] == 'drpall', 'Order of files changed'
     assert files[2].split('.')[0] == '12704', 'Image file name changed'
 
-if __name__ == '__main__':
-    test_files()
+
+@requires_remote
+def test_sbholes():
+    maps_file = remote_data_file('manga-8138-12704-MAPS-{0}.fits.gz'.format(dap_test_daptype))
+
+    kin = manga.MaNGAGasKinematics(maps_file, flux_bound=(0, 100))
+    sb = kin.remap('sb')
+
+    _sb = util.gaussian_fill(sb)
+
+    assert numpy.sum(_sb - sb.filled(0.0) > 0) > 250, 'Number of fixed spaxels changed.'
 
 

--- a/nirvana/tests/util.py
+++ b/nirvana/tests/util.py
@@ -23,6 +23,8 @@ def remote_data_file(filename=None):
     root = os.path.join(data_file(), 'remote')
     return root if filename is None else os.path.join(root, filename)
 
+# TODO: It's super annoying that these file names do not include the plate
+# number...
 def remote_drp_test_images():
     return ['12704.png', '12703.png']
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Package dependencies for nirvana
 setuptools>=46.1
+wheel>=0.36         # Needed for pydl
 ipython>=7.14
 numpy>=1.18.4
 scipy>=1.6

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def get_requirements():
 
 NAME = 'nirvana'
 # do not use x.x.x-dev.  things complain.  instead use x.x.xdev
-VERSION = '0.1.1'
+VERSION = '0.1.2dev'
 RELEASE = 'dev' not in VERSION
 
 def run_setup(data_files, scripts, packages, install_requires):


### PR DESCRIPTION
This makes a couple of minor changes to how the surface-brightness maps can be treated.

 - Allows the surface-brightness used during the model construction to be defined separately from the binned surface-brightness data.  This is useful for modeling the stellar kinematics.
 - Allow the surface-brightness masks to be patched by a Gaussian smoothing algorithm to fill surface-brightness holes.

Neither of these have had a significant effect on the results for the few test cases I've run.  I think the first one is useful for heavily binned galaxies, but we should tread carefully with the second...

This also adds the `PowerExp` 1D function, which I've used in playing around with parametric bisymmetric models.