### PR TITLE
Disk parent class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,13 @@
  - Added new asymmetry map calculations and plots
  - Begins development of a `BisymmetricDisk` class the mimics the
    `AxisymmetricDisk` class.
+ - Consolidate common functionality between `AxisymmetricDisk` and
+   `BisymmetricDisk` into a common parent class called `ThinDisk`.
+ - Construct radial profiles of deprojected kinematics
+ - Save radial profiles along the major and minor axes of both the tangential
+   speed and the velocity dispersion
+ - Fit rejection iterations moved to common parent class, `ThinDisk`.
+   
 
 
 0.1.0

--- a/nirvana/data/meta.py
+++ b/nirvana/data/meta.py
@@ -15,7 +15,7 @@ from astropy.io import fits
 from astropy.cosmology import FlatLambdaCDM
 
 from ..models.geometry import projected_polar
-from .util import select_major_axis
+from .util import select_kinematic_axis
 
 class GlobalPar:
     r"""
@@ -181,7 +181,8 @@ class GlobalPar:
         r, th = projected_polar(x, y, np.radians(self.pa),
                                 np.radians(self.guess_inclination(lb=1., ub=89.)))
         # Create a mask that selects data near the major axis
-        gpm = select_major_axis(r, th, r_range=r_range, wedge=wedge)
+        gpm = select_kinematic_axis(r, th, which='major', r_range=r_range, wedge=wedge)
+#        gpm = select_major_axis(r, th, r_range=r_range, wedge=wedge)
         # Include any input mask
         gpm |= np.logical_not(np.ma.getmaskarray(v))
 

--- a/nirvana/data/util.py
+++ b/nirvana/data/util.py
@@ -704,16 +704,20 @@ def bin_stats(x, y, bin_center, bin_width, ye=None, wgts=None, gpm=None, eps=Non
              ntot, nbin, all_bin_gpm
 
 
-def select_major_axis(r, th, r_range=None, wedge=30.):
+def select_kinematic_axis(r, th, which='major', r_range=None, wedge=30.):
     r"""
-    Return a boolean array that selects data near the major axis.
+    Return a boolean array that selects data within a defined angular wedget
+    about a kinematic axis.
 
     Args:
         r (`numpy.ndarray`_):
             In-plane disk radius relative to the center.
         th (`numpy.ndarray`_):
             In-plane disk azimuth in *radians* relative to the receding side
-            of the major axis.
+            of the major axis.  Expected range is :math:`[0,2\pi)`
+        which (:obj:`str`, optional):
+            The axis about which to select data.  Must be either ``'major'`` or
+            ``'minor'``.
         r_range (:obj:`str`, array-like, optional):
             The lower and upper limit of the radial range over which to
             measure the median rotation velocity. If None, the radial range
@@ -730,8 +734,14 @@ def select_major_axis(r, th, r_range=None, wedge=30.):
     """
     # Select the spaxels within the wedge around the major axis
     _wedge = np.radians(wedge)
-    gpm = (th < _wedge) | (th > 2*np.pi - _wedge) \
-            | ((th > np.pi - _wedge) & (th < np.pi + _wedge))
+    if which == 'major':
+        gpm = (th < _wedge) | (th > 2*np.pi - _wedge) \
+                | ((th > np.pi - _wedge) & (th < np.pi + _wedge))
+    elif which == 'minor':
+        gpm = ((th > np.pi/2 - _wedge) & (th < np.pi/2 + _wedge)) \
+                | ((th > 3*np.pi/2 - _wedge) & (th < 3*np.pi/2 + _wedge))
+    else:
+        raise ValueError('Selected kinematic axis must be major or minor.')
 
     if r_range == 'all':
         # Do not select based on radius

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -55,7 +55,7 @@ def disk_fit_reject(kin, disk, disp=None, ignore_covar=True, vel_mask=None, vel_
         disp (:obj:`bool`, optional):
             Flag to include the velocity dispersion rejection in the
             iteration. If None, rejection is included if ``kin`` has velocity
-            dispersion data and ``disk`` has a disperion parameterization.
+            dispersion data and ``disk`` has a dispersion parameterization.
         ignore_covar (:obj:`bool`, optional):
             If ``kin`` provides the covariance between measurements, ignore it.
         vel_mask (`numpy.ndarray`_):

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -15,300 +15,20 @@ from matplotlib import pyplot, rc, patches, ticker, colors
 
 from astropy.io import fits
 
-from .oned import HyperbolicTangent, Exponential, ExpBase, Const, PolyEx
 from .geometry import projected_polar, deriv_projected_polar
 from .beam import smear, deriv_smear
+from . import oned 
 from . import asymmetry
 from ..data.kinematics import Kinematics
 from ..data.scatter import IntrinsicScatter
 from ..data.util import inverse, find_largest_coherent_region
-from ..data.util import select_major_axis, bin_stats, growth_lim, atleast_one_decade
+from ..data.util import select_kinematic_axis, bin_stats, growth_lim, atleast_one_decade
 from ..util import plot
 from ..util import fileio
 
 from .thindisk import ThinDisk
 
 #warnings.simplefilter('error', RuntimeWarning)
-
-# TODO: Make this a member function of AxisymmetricDisk?
-def disk_fit_reject(kin, disk, disp=None, ignore_covar=True, vel_mask=None, vel_sigma_rej=5,
-                    show_vel=False, vel_plot=None, sig_mask=None, sig_sigma_rej=5, show_sig=False,
-                    sig_plot=None, rej_flag='REJ_RESID', verbose=False):
-    """
-    Reject kinematic data based on the error-weighted residuals with respect
-    to a disk model.
-
-    The rejection iteration is done using
-    :class:`~nirvana.data.scatter.IntrinsicScatter`, independently for the
-    velocity and velocity dispersion measurements (if the latter is selected
-    and/or available).
-
-    Note that you can both show the QA plots and have them written to a file
-    (e.g., ``show_vel`` can be True and ``vel_plot`` can provide a file).
-
-    Args:
-        kin (:class:`~nirvana.data.kinematics.Kinematics`):
-            Object with the data being fit.
-        disk (:class:`~nirvana.models.axisym.AxisymmetricDisk`):
-            Object that performed the fit and has the best-fitting parameters.
-        disp (:obj:`bool`, optional):
-            Flag to include the velocity dispersion rejection in the
-            iteration. If None, rejection is included if ``kin`` has velocity
-            dispersion data and ``disk`` has a dispersion parameterization.
-        ignore_covar (:obj:`bool`, optional):
-            If ``kin`` provides the covariance between measurements, ignore it.
-        vel_mask (`numpy.ndarray`_):
-            Bitmask used to track velocity rejections.
-        vel_sigma_rej (:obj:`float`, optional):
-            Rejection sigma for the velocity measurements.  If None, no data are
-            rejected and the function basically just measures the intrinsic
-            scatter.
-        show_vel (:obj:`bool`, optional):
-            Show the QA plot for the velocity rejection (see
-            :func:`~nirvana.data.scatter.IntrinsicScatter.show`).
-        vel_plot (:obj:`str`, optional):
-            Write the QA plot for the velocity rejection to this file (see
-            :func:`~nirvana.data.scatter.IntrinsicScatter.show`).
-        sig_mask (`numpy.ndarray`_):
-            Bitmask used to track dispersion rejections.
-        sig_sigma_rej (:obj:`float`, optional):
-            Rejection sigma for the dispersion measurements.  If None, no data
-            are rejected and the function basically just measures the intrinsic
-            scatter.
-        show_sig (:obj:`bool`, optional):
-            Show the QA plot for the velocity dispersion rejection (see
-            :func:`~nirvana.data.scatter.IntrinsicScatter.show`).
-        sig_plot (:obj:`str`, optional):
-            Write the QA plot for the velocity dispersion rejection to this
-            file (see :func:`~nirvana.data.scatter.IntrinsicScatter.show`).
-        rej_flag (:obj:`str`, optional):
-            Rejection flag giving the reason these data were rejected. Must be a
-            valid flag for :class:`~nirvana.models.thindisk.ThinDiskFitBitMask`.
-        verbose (:obj:`bool`, optional):
-            Verbose scatter fitting output.
-
-    Returns:
-        :obj:`tuple`: Returns two pairs of objects, one for each kinematic
-        moment. The first object is the vector flagging the data that should
-        be rejected and the second is the estimated intrinsic scatter about
-        the model. If the dispersion is not included in the rejection, the
-        last two objects returned are both None.
-    """
-
-    # Check input
-    if disp is None:
-        disp = kin.sig is not None and disk.dc is not None
-    if disp and (kin.sig is None or disk.dc is None):
-        raise ValueError('Cannot include dispersion if there is no dispersion data or if the '
-                         'dispersion data were not fit by the model.')
-    use_covar = not ignore_covar and kin.vel_covar is not None
-    if disp:
-        use_covar = use_covar and kin.sig_phys2_covar is not None
-
-    # Get the models
-    models = disk.model()
-    _verbose = 2 if verbose else 0
-
-    # Reject based on error-weighted residuals, accounting for intrinsic
-    # scatter
-    vmod = models[0] if len(models) == 2 else models
-    resid = kin.vel - kin.bin(vmod)
-    v_err_kwargs = {'covar': kin.vel_covar} if use_covar \
-                        else {'err': np.sqrt(inverse(kin.vel_ivar))}
-    scat = IntrinsicScatter(resid, gpm=disk.vel_gpm, npar=disk.nfree, **v_err_kwargs)
-    vel_sig, vel_rej, vel_gpm = scat.iter_fit(sigma_rej=vel_sigma_rej, fititer=5, verbose=_verbose)
-    # Incorporate into mask
-    if vel_mask is not None and np.any(vel_rej):
-        vel_mask[vel_rej] = disk.mbm.turn_on(vel_mask[vel_rej], rej_flag)
-
-    # Show and/or plot the result, if requested
-    if show_vel:
-        scat.show()
-    if vel_plot is not None:
-        scat.show(ofile=vel_plot)
-
-    if not disp:
-        # Not rejecting dispersion so we're done
-        return vel_rej, vel_sig, None, None
-
-    # Reject based on error-weighted residuals, accounting for intrinsic
-    # scatter
-    resid = kin.sig_phys2 - kin.bin(models[1])**2
-    sig_err_kwargs = {'covar': kin.sig_phys2_covar} if use_covar \
-                        else {'err': np.sqrt(inverse(kin.sig_phys2_ivar))}
-    scat = IntrinsicScatter(resid, gpm=disk.sig_gpm, npar=disk.nfree, **sig_err_kwargs)
-    sig_sig, sig_rej, sig_gpm = scat.iter_fit(sigma_rej=sig_sigma_rej, fititer=5, verbose=_verbose)
-    # Incorporate into mask
-    if sig_mask is not None and np.any(sig_rej):
-        sig_mask[sig_rej] = disk.mbm.turn_on(sig_mask[sig_rej], rej_flag)
-    # Show and/or plot the result, if requested
-    if show_sig:
-        scat.show()
-    if sig_plot is not None:
-        scat.show(ofile=sig_plot)
-
-    return vel_rej, vel_sig, sig_rej, sig_sig
-
-
-# TODO: Consolidate this function with the one above
-def disk_fit_resid_dist(kin, disk, disp=None, ignore_covar=True, vel_mask=None, show_vel=False,
-                        vel_plot=None, sig_mask=None, show_sig=False, sig_plot=None):
-    """
-    Construct plots of the distribution of the fit residuals.
-
-    Components of this function is very similar to :func:`disk_fit_reject`.  No
-    rejection is performed, though, and the method simply shows the current
-    distribution of residuals.
-
-    Args:
-        kin (:class:`~nirvana.data.kinematics.Kinematics`):
-            Object with the data being fit.
-        disk (:class:`~nirvana.models.axisym.AxisymmetricDisk`):
-            Object that performed the fit and has the best-fitting parameters.
-        disp (:obj:`bool`, optional):
-            Flag to include the velocity dispersion rejection in the
-            iteration. If None, rejection is included if ``kin`` has velocity
-            dispersion data and ``disk`` has a disperion parameterization.
-        ignore_covar (:obj:`bool`, optional):
-            If ``kin`` provides the covariance between measurements, ignore it.
-        vel_mask (`numpy.ndarray`_):
-            Bitmask used to track velocity rejections.
-        show_vel (:obj:`bool`, optional):
-            Show the QA plot for the velocity rejection (see
-            :func:`~nirvana.data.scatter.IntrinsicScatter.show`).
-        vel_plot (:obj:`str`, optional):
-            Write the QA plot for the velocity rejection to this file (see
-            :func:`~nirvana.data.scatter.IntrinsicScatter.show`).
-        sig_mask (`numpy.ndarray`_):
-            Bitmask used to track dispersion rejections.
-        show_sig (:obj:`bool`, optional):
-            Show the QA plot for the velocity dispersion rejection (see
-            :func:`~nirvana.data.scatter.IntrinsicScatter.show`).
-        sig_plot (:obj:`str`, optional):
-            Write the QA plot for the velocity dispersion rejection to this
-            file (see :func:`~nirvana.data.scatter.IntrinsicScatter.show`).
- 
-    """
-    # Check input
-    if disp is None:
-        disp = kin.sig is not None and disk.dc is not None
-    if disp and (kin.sig is None or disk.dc is None):
-        raise ValueError('Cannot include dispersion if there is no dispersion data or if the '
-                         'dispersion data were not fit by the model.')
-    use_covar = not ignore_covar and kin.vel_covar is not None
-    if disp:
-        use_covar = use_covar and kin.sig_phys2_covar is not None
-
-    # Get the models
-    models = disk.model()
-
-    # Show the error-normalized distributions for the velocity-field residuals
-    vmod = models[0] if len(models) == 2 else models
-    resid = kin.vel - kin.bin(vmod)
-    v_err_kwargs = {'covar': kin.vel_covar} if use_covar \
-                        else {'err': np.sqrt(inverse(kin.vel_ivar))}
-    scat = IntrinsicScatter(resid, gpm=disk.vel_gpm, npar=disk.nfree, **v_err_kwargs)
-    scat.sig = 0. if disk.scatter is None else disk.scatter[0]
-    scat.rej = np.zeros(resid.size, dtype=bool) if vel_mask is None else vel_mask > 0
-    # Show and/or plot the result, if requested
-    if show_vel:
-        scat.show(title='Velocity field residuals')
-    if vel_plot is not None:
-        scat.show(ofile=vel_plot, title='Velocity field residuals')
-
-    # Decide if we're done
-    if disp is None:
-        disp = kin.sig is not None and disk.dc is not None
-    if not disp:
-        # Yep
-        return
-
-    # Show the error-normalized distributions for the dispersion residuals
-    resid = kin.sig_phys2 - kin.bin(models[1])**2
-    sig_err_kwargs = {'covar': kin.sig_phys2_covar} if use_covar \
-                        else {'err': np.sqrt(inverse(kin.sig_phys2_ivar))}
-    scat = IntrinsicScatter(resid, gpm=disk.sig_gpm, npar=disk.nfree, **sig_err_kwargs)
-    scat.sig = 0. if disk.scatter is None else disk.scatter[1]
-    scat.rej = np.zeros(resid.size, dtype=bool) if sig_mask is None else sig_mask > 0
-    # Show and/or plot the result, if requested
-    if show_sig:
-        scat.show(title='Dispersion field residuals')
-    if sig_plot is not None:
-        scat.show(ofile=sig_plot, title='Dispersion field residuals')
-
-
-# TODO: Make this a method in AxisymmetricDisk?
-def reset_to_base_flags(disk, kin, vel_mask, sig_mask):
-    """
-    Reset the masks to only include the "base" flags.
-    
-    As the best-fit parameters change over the course of a set of rejection
-    iterations, the residuals with respect to the model change. This method
-    resets the flags back to the base-level rejection (i.e., independent of
-    the model), allowing the rejection to be based on the most recent set of
-    parameters and potentially recovering good data that was previously
-    rejected because of a poor model fit.
-
-    .. warning::
-        The objects are *all* modified in place.
-
-    Args:
-        disk (:class:`~nirvana.models.axisym.AxisymmetricDisk`):
-            Object that performed the fit and has the best-fitting parameters.
-        kin (:class:`~nirvana.data.kinematics.Kinematics`):
-            Object with the data being fit.
-        vel_mask (`numpy.ndarray`_):
-            Bitmask used to track velocity rejections.
-        sig_mask (`numpy.ndarray`_):
-            Bitmask used to track dispersion rejections. Can be None.
-    """
-    # Turn off the relevant rejection for all pixels
-    vel_mask = disk.mbm.turn_off(vel_mask, flag='REJ_RESID')
-    # Reset the data mask held by the Kinematics object
-    kin.vel_mask = disk.mbm.flagged(vel_mask, flag=disk.mbm.base_flags())
-    if sig_mask is not None:
-        # Turn off the relevant rejection for all pixels
-        sig_mask = disk.mbm.turn_off(sig_mask, flag='REJ_RESID')
-        # Reset the data mask held by the Kinematics object
-        kin.sig_mask = disk.mbm.flagged(sig_mask, flag=disk.mbm.base_flags())
-
-
-#class AxisymmetricDiskFitBitMask(BitMask):
-#    """
-#    Bin-by-bin mask used to track axisymmetric disk fit rejections.
-#    """
-#    def __init__(self):
-#        # TODO: np.array just used for slicing convenience
-#        mask_def = np.array([['DIDNOTUSE', 'Data not used because it was flagged on input.'],
-#                             ['REJ_ERR', 'Data rejected because of its large measurement error.'],
-#                             ['REJ_SNR', 'Data rejected because of its low signal-to-noise.'],
-#                             ['REJ_UNR', 'Data rejected after first iteration and are so '
-#                                         'discrepant from the other data that we expect the '
-#                                         'measurements are unreliable.'],
-#                             ['REJ_RESID', 'Data rejected due to iterative rejection process '
-#                                           'of model residuals.'],
-#                             ['DISJOINT', 'Data part of a smaller disjointed region, not '
-#                                          'congruent with the main body of the measurements.']])
-#        super().__init__(mask_def[:,0], descr=mask_def[:,1])
-#
-#    @staticmethod
-#    def base_flags():
-#        """
-#        Return the list of "base-level" flags that are *always* ignored,
-#        regardless of the fit iteration.
-#        """
-#        return ['DIDNOTUSE', 'REJ_ERR', 'REJ_SNR', 'REJ_UNR', 'DISJOINT']
-#
-#
-#class AxisymmetricDiskGlobalBitMask(BitMask):
-#    """
-#    Fit-wide quality flag.
-#    """
-#    def __init__(self):
-#        # NOTE: np.array just used for slicing convenience
-#        mask_def = np.array([['LOWINC', 'Fit has an erroneously low inclination']])
-#        super().__init__(mask_def[:,0], descr=mask_def[:,1])
-
 
 class AxisymmetricDisk(ThinDisk):
     r"""
@@ -339,7 +59,7 @@ class AxisymmetricDisk(ThinDisk):
 
     Importantly, note that the model fits the parameters for the *projected*
     rotation curve. I.e., that amplitude of the fitted function is actually
-    :math:`V_{\rm rot} \sin i`.
+    :math:`V_\theta\ \sin i`.
 
     .. todo::
         Describe the attributes
@@ -353,20 +73,9 @@ class AxisymmetricDisk(ThinDisk):
             None, the dispersion profile is not included in the fit!
 
     """
-
-#    gbm = AxisymmetricDiskGlobalBitMask()
-#    """
-#    Global bitmask.
-#    """
-#
-#    mbm = AxisymmetricDiskFitBitMask()
-#    """
-#    Measurement-specific bitmask.
-#    """
-
     def __init__(self, rc=None, dc=None):
         # Rotation curve
-        self.rc = HyperbolicTangent() if rc is None else rc
+        self.rc = oned.HyperbolicTangent() if rc is None else rc
         # Velocity dispersion curve (can be None)
         self.dc = dc
 
@@ -767,7 +476,7 @@ class AxisymmetricDisk(ThinDisk):
 # TODO:
 #   - This is MaNGA-specific and needs to be abstracted
 #   - Copy over the DataTable class from the DAP, or use an astropy.table.Table?
-def _fit_meta_dtype(par_names):
+def _fit_meta_dtype(par_names, nr):
     """
     Set the data type for a `numpy.recarray`_ used to hold metadata of the
     best-fit model.
@@ -775,6 +484,8 @@ def _fit_meta_dtype(par_names):
     Args:
         par_names (array-like):
             Array of strings with the short names for the model parameters.
+        nr (:obj:`int`):
+            Number radial bins for azimuthally averaged profiles
 
     Returns:
         :obj:`list`: The list of tuples providing the name, data type, and shape
@@ -894,7 +605,38 @@ def _fit_meta_dtype(par_names):
             # Status index of the fit returned by scipy.optimize.least_squares
             ('STATUS', np.int),
             # A simple boolean indication that the fit did not fault
-            ('SUCCESS', np.int)] + gp + bp + bpe
+            ('SUCCESS', np.int)] + gp + bp + bpe + \
+           [('BINR', float, (nr,)),
+            ('V_MAJ', float, (nr,)),
+            ('V_MAJ_SDEV', float, (nr,)),
+            ('V_MAJ_NTOT', float, (nr,)),
+            ('V_MAJ_NUSE', float, (nr,)),
+            ('V_MAJ_MOD', float, (nr,)),
+            ('V_MAJ_MOD_SDEV', float, (nr,)),
+            ('V_MIN', float, (nr,)),
+            ('V_MIN_SDEV', float, (nr,)),
+            ('V_MIN_NTOT', float, (nr,)),
+            ('V_MIN_NUSE', float, (nr,)),
+            ('V_MIN_MOD', float, (nr,)),
+            ('V_MIN_MOD_SDEV', float, (nr,)),
+            ('S_ALL', float, (nr,)),
+            ('S_ALL_SDEV', float, (nr,)),
+            ('S_ALL_NTOT', float, (nr,)),
+            ('S_ALL_NUSE', float, (nr,)),
+            ('S_ALL_MOD', float, (nr,)),
+            ('S_ALL_MOD_SDEV', float, (nr,)),
+            ('S_MAJ', float, (nr,)),
+            ('S_MAJ_SDEV', float, (nr,)),
+            ('S_MAJ_NTOT', float, (nr,)),
+            ('S_MAJ_NUSE', float, (nr,)),
+            ('S_MAJ_MOD', float, (nr,)),
+            ('S_MAJ_MOD_SDEV', float, (nr,)),
+            ('S_MIN', float, (nr,)),
+            ('S_MIN_SDEV', float, (nr,)),
+            ('S_MIN_NTOT', float, (nr,)),
+            ('S_MIN_NUSE', float, (nr,)),
+            ('S_MIN_MOD', float, (nr,)),
+            ('S_MIN_MOD_SDEV', float, (nr,))]
 
 
 # TODO: This is MaNGA-specific and needs to be abstracted
@@ -972,9 +714,30 @@ def axisym_fit_data(galmeta, kin, p0, disk, ofile, vmask, smask):
                                   np.ma.getmaskarray(sig_y).copy(),
                                   np.ma.getmaskarray(sig_xy).copy()])
 
+    # Get the error-weighted mean radial profiles
+    models = disk.model()
+    if disk.dc is None:
+        vmod = kin.bin(models)
+        smod = None
+    else:
+        vmod = kin.bin(models[0])
+        smod = kin.bin(models[1])
+    fwhm = galmeta.psf_fwhm[1]  # Selects r band!
+    oversample = 1.5
+    maj_wedge = 30.
+    min_wedge = 10.
+    binr, vrot_ewmean, vrot_ewsdev, vrot_ntot, vrot_nbin, vrotm_ewmean, vrotm_ewsdev, \
+        vrad_ewmean, vrad_ewsdev, vrad_ntot, vrad_nbin, vradm_ewmean, vradm_ewsdev, \
+        sprof_ewmean, sprof_ewsdev, sprof_ntot, sprof_nbin, sprofm_ewmean, sprofm_ewsdev, \
+        smaj_ewmean, smaj_ewsdev, smaj_ntot, smaj_nbin, smajm_ewmean, smajm_ewsdev, \
+        smin_ewmean, smin_ewsdev, smin_ntot, smin_nbin, sminm_ewmean, sminm_ewsdev \
+            = kin.radial_profiles(fwhm/oversample, xc=disk.par[0], yc=disk.par[1], pa=disk.par[2],
+                                  inc=disk.par[3], vsys=disk.par[4], maj_wedge=maj_wedge,
+                                  min_wedge=min_wedge, vel_mod=vmod, sig_mod=smod)
+
     # Instantiate the single-row table with the metadata:
     disk_par_names = disk.par_names(short=True)
-    metadata = fileio.init_record_array(1, _fit_meta_dtype(disk_par_names))
+    metadata = fileio.init_record_array(1, _fit_meta_dtype(disk_par_names, binr.size))
 
     # Fill the fit-independent data
     metadata['MANGAID'] = galmeta.mangaid
@@ -989,11 +752,49 @@ def axisym_fit_data(galmeta, kin, p0, disk, ofile, vmask, smask):
     metadata['PA'] = galmeta.pa
     metadata['ELL'] = galmeta.ell
     metadata['Q0'] = galmeta.q0
+
+    # Fill the radial profiles
+    metadata['BINR'] = binr
+
+    metadata['V_MAJ'] = vrot_ewmean
+    metadata['V_MAJ_SDEV'] = vrot_ewsdev
+    metadata['V_MAJ_NTOT'] = vrot_ntot
+    metadata['V_MAJ_NUSE'] = vrot_nbin
+    metadata['V_MAJ_MOD'] = vrotm_ewmean
+    metadata['V_MAJ_MOD_SDEV'] = vrotm_ewsdev
+    
+    metadata['V_MIN'] = vrad_ewmean
+    metadata['V_MIN_SDEV'] = vrad_ewsdev
+    metadata['V_MIN_NTOT'] = vrad_ntot
+    metadata['V_MIN_NUSE'] = vrad_nbin
+    metadata['V_MIN_MOD'] = vradm_ewmean
+    metadata['V_MIN_MOD_SDEV'] = vradm_ewsdev
+    
+    metadata['S_ALL'] = sprof_ewmean
+    metadata['S_ALL_SDEV'] = sprof_ewsdev
+    metadata['S_ALL_NTOT'] = sprof_ntot
+    metadata['S_ALL_NUSE'] = sprof_nbin
+    metadata['S_ALL_MOD'] = sprofm_ewmean
+    metadata['S_ALL_MOD_SDEV'] = sprofm_ewsdev
+    
+    metadata['S_MAJ'] = smaj_ewmean
+    metadata['S_MAJ_SDEV'] = smaj_ewsdev
+    metadata['S_MAJ_NTOT'] = smaj_ntot
+    metadata['S_MAJ_NUSE'] = smaj_nbin
+    metadata['S_MAJ_MOD'] = smajm_ewmean
+    metadata['S_MAJ_MOD_SDEV'] = smajm_ewsdev
+    
+    metadata['S_MIN'] = smin_ewmean
+    metadata['S_MIN_SDEV'] = smin_ewsdev
+    metadata['S_MIN_NTOT'] = smin_ntot
+    metadata['S_MIN_NUSE'] = smin_nbin
+    metadata['S_MIN_MOD'] = sminm_ewmean
+    metadata['S_MIN_MOD_SDEV'] = sminm_ewsdev
     
     # Best-fit model maps and fit-residual stats
     # TODO: Don't bin the intrinsic model?
     # TODO: Include the binned radial profiles shown in the output plot?
-    models = disk.model()
+#    models = disk.model()
     intr_models = disk.model(ignore_beam=True)
     vfom, sfom = disk._get_fom()(disk.par, sep=True)
     if disk.dc is None:
@@ -1299,52 +1100,44 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
         smod_intr = kin.bin(intr_models[1])
         smod_intr_map = kin.remap(smod_intr, mask=kin.sig_mask)
 
+    # Get the error-weighted mean radial profiles
+    fwhm = galmeta.psf_fwhm[1]  # Selects r band!
+    oversample = 1.5
+    maj_wedge = 30.
+    min_wedge = 10.
+    binr, vrot_ewmean, vrot_ewsdev, vrot_ntot, vrot_nbin, vrotm_ewmean, vrotm_ewsdev, \
+        vrad_ewmean, vrad_ewsdev, vrad_ntot, vrad_nbin, vradm_ewmean, vradm_ewsdev, \
+        sprof_ewmean, sprof_ewsdev, sprof_ntot, sprof_nbin, sprofm_ewmean, sprofm_ewsdev, \
+        smaj_ewmean, smaj_ewsdev, smaj_ntot, smaj_nbin, smajm_ewmean, smajm_ewsdev, \
+        smin_ewmean, smin_ewsdev, smin_ntot, smin_nbin, sminm_ewmean, sminm_ewsdev \
+            = kin.radial_profiles(fwhm/oversample, xc=disk.par[0], yc=disk.par[1], pa=disk.par[2],
+                                  inc=disk.par[3], vsys=disk.par[4], maj_wedge=maj_wedge,
+                                  min_wedge=min_wedge, vel_mod=vmod, sig_mod=smod)
+
     # Get the projected rotational velocity
     #   - Disk-plane coordinates
     r, th = projected_polar(kin.x - disk.par[0], kin.y - disk.par[1], *np.radians(disk.par[2:4]))
     #   - Mask for data along the major axis
-    wedge = 30.
-    major_gpm = select_major_axis(r, th, r_range='all', wedge=wedge)
+    major_gpm = select_kinematic_axis(r, th, which='major', r_range='all', wedge=maj_wedge)
+    minor_gpm = select_kinematic_axis(r, th, which='minor', r_range='all', wedge=min_wedge)
     #   - Projected rotation velocities
     indx = major_gpm & np.logical_not(kin.vel_mask)
     vrot_r = r[indx]
     vrot = (kin.vel[indx] - disk.par[4])/np.cos(th[indx])
-    vrot_wgt = kin.vel_ivar[indx]*np.cos(th[indx])**2
-    vrot_err = np.sqrt(inverse(vrot_wgt))
-    vrot_mod = (vmod[indx] - disk.par[4])/np.cos(th[indx])
-
-    # Get the binned data and the 1D model profiles
-    fwhm = galmeta.psf_fwhm[1]  # Selects r band!
-    maxr = np.amax(r)
-    modelr = np.arange(0, maxr, 0.1)
-    binr = np.arange(fwhm/2, maxr, fwhm)
-    binw = np.full(binr.size, fwhm, dtype=float)
-    indx = major_gpm & np.logical_not(kin.vel_mask)
-    _, vrot_uwmed, vrot_uwmad, _, _, _, _, vrot_ewmean, vrot_ewsdev, vrot_ewerr, vrot_ntot, \
-        vrot_nbin, vrot_bin_gpm = bin_stats(vrot_r, vrot, binr, binw, wgts=vrot_wgt,
-                                            fill_value=0.0) 
-    # Construct the binned model RC using the same weights
-    _, vrotm_uwmed, vrotm_uwmad, _, _, _, _, vrotm_ewmean, vrotm_ewsdev, vrotm_ewerr, vrotm_ntot, \
-        vrotm_nbin, _ = bin_stats(vrot_r[vrot_bin_gpm], vrot_mod[vrot_bin_gpm], binr, binw,
-                                  wgts=vrot_wgt[vrot_bin_gpm], fill_value=0.0) 
-    # Finely sampled 1D model rotation curve
-    vrot_intr_model = disk.rc.sample(modelr, par=disk.rc_par())
-
+    #   - Projected radial velocities
+    indx = minor_gpm & np.logical_not(kin.vel_mask)
+    vrad_r = r[indx]
+    vrad = (kin.vel[indx] - disk.par[4])/np.sin(th[indx])
     if smod is not None:
         indx = np.logical_not(kin.sig_mask) & (kin.sig_phys2 > 0)
         sprof_r = r[indx]
         sprof = np.sqrt(kin.sig_phys2[indx])
-        sprof_wgt = 4*kin.sig_phys2[indx]*kin.sig_phys2_ivar[indx]
-        sprof_err = np.sqrt(inverse(sprof_wgt))
-        _, sprof_uwmed, sprof_uwmad, _, _, _, _, sprof_ewmean, sprof_ewsdev, sprof_ewerr, \
-            sprof_ntot, sprof_nbin, sprof_bin_gpm \
-                    = bin_stats(sprof_r, sprof, binr, binw, wgts=sprof_wgt, fill_value=0.0) 
-        # Construct the binned model dispersion profile using the same weights
-        _, sprofm_uwmed, sprofm_uwmad, _, _, _, _, sprofm_ewmean, sprofm_ewsdev, sprofm_ewerr, \
-            sprofm_ntot, sprofm_nbin, _ \
-                    = bin_stats(r[indx][sprof_bin_gpm], smod[indx][sprof_bin_gpm], binr, binw,
-                                wgts=sprof_wgt[sprof_bin_gpm], fill_value=0.0) 
-        # Finely sampled 1D model dispersion profile
+
+    # Get the 1D model profiles
+    maxr = np.amax(r)
+    modelr = np.arange(0, maxr, 0.1)
+    vrot_intr_model = disk.rc.sample(modelr, par=disk.rc_par())
+    if smod is not None:
         sprof_intr_model = disk.dc.sample(modelr, par=disk.dc_par())
 
     # Set the extent for the 2D maps
@@ -1757,6 +1550,9 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
     vrot_indx = vrot_nbin > 5
     if not np.any(vrot_indx):
         vrot_indx = vrot_nbin > 0
+    vrad_indx = vrad_nbin > 5
+    if not np.any(vrad_indx):
+        vrad_indx = vrad_nbin > 0
     if disk.dc is not None:
         sprof_indx = sprof_nbin > 5
         if not np.any(sprof_indx):
@@ -1785,9 +1581,13 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
 
     #-------------------------------------------------------------------
     # Rotation curve
-    maxrc = np.amax(np.append(vrot_ewmean[vrot_indx], vrotm_ewmean[vrot_indx])) \
-                if np.any(vrot_indx) else np.amax(vrot_intr_model)
-    rc_lim = [0.0, maxrc*1.1]
+#    maxrc = np.amax(np.append(vrot_ewmean[vrot_indx], vrotm_ewmean[vrot_indx])) \
+#                if np.any(vrot_indx) else np.amax(vrot_intr_model)
+#    rc_lim = [0.0, maxrc*1.1]
+
+    rc_lim = growth_lim(np.concatenate((vrot_ewmean[vrot_indx], vrotm_ewmean[vrot_indx],
+                                        vrad_ewmean[vrad_indx], vradm_ewmean[vrad_indx])),
+                        0.99, 1.3)
 
     reff_lines = np.arange(galmeta.reff, r_lim[1], galmeta.reff) if galmeta.reff > 1 else None
 
@@ -1808,7 +1608,16 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
                    alpha=1.0, facecolors='0.5', zorder=3)
         ax.scatter(binr[indx], vrotm_ewmean[indx], edgecolors='C3', marker='o', lw=3, s=100,
                    alpha=1.0, facecolors='none', zorder=4)
-        ax.errorbar(binr[indx], vrot_ewmean[indx], yerr=vrot_ewsdev[indx], color='0.6', capsize=0,
+        ax.errorbar(binr[indx], vrot_ewmean[indx], yerr=vrot_ewsdev[indx], color='0.5', capsize=0,
+                    linestyle='', linewidth=1, alpha=1.0, zorder=2)
+    indx = vrad_nbin > 0
+    ax.scatter(vrad_r, vrad, marker='.', color='0.6', s=30, lw=0, alpha=0.6, zorder=1)
+    if np.any(indx):
+        ax.scatter(binr[indx], vrad_ewmean[indx], marker='o', edgecolors='none', s=100,
+                   alpha=1.0, facecolors='0.7', zorder=3)
+        ax.scatter(binr[indx], vradm_ewmean[indx], edgecolors='C1', marker='o', lw=3, s=100,
+                   alpha=1.0, facecolors='none', zorder=4)
+        ax.errorbar(binr[indx], vrad_ewmean[indx], yerr=vrad_ewsdev[indx], color='0.7', capsize=0,
                     linestyle='', linewidth=1, alpha=1.0, zorder=2)
     ax.plot(modelr, vrot_intr_model, color='C3', zorder=5, lw=0.5)
     if reff_lines is not None:
@@ -1835,11 +1644,11 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
     axt.tick_params(which='both', axis='y', colors='0.4')
     axt.yaxis.label.set_color('0.4')
 
-    ax.add_patch(patches.Rectangle((0.62,0.03), 0.36, 0.19, facecolor='w', lw=0, edgecolor='none',
+    ax.add_patch(patches.Rectangle((0.66,0.55), 0.32, 0.19, facecolor='w', lw=0, edgecolor='none',
                                    zorder=5, alpha=0.7, transform=ax.transAxes))
-    ax.text(0.97, 0.13, r'$V_{\rm rot}\ \sin i$ [km/s; left axis]', ha='right', va='bottom',
+    ax.text(0.97, 0.65, r'$V\ \sin i$ [km/s; left axis]', ha='right', va='bottom',
             transform=ax.transAxes, fontsize=10, zorder=6)
-    ax.text(0.97, 0.04, r'$V_{\rm rot}$ [km/s; right axis]', ha='right', va='bottom', color='0.4',
+    ax.text(0.97, 0.56, r'$V$ [km/s; right axis]', ha='right', va='bottom', color='0.4',
             transform=ax.transAxes, fontsize=10, zorder=6)
 
     #-------------------------------------------------------------------
@@ -1893,6 +1702,41 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
 
     # Reset to default style
     pyplot.rcdefaults()
+
+
+def reset_to_base_flags(disk, kin, vel_mask, sig_mask):
+    """
+    Reset the masks to only include the "base" flags.
+    
+    As the best-fit parameters change over the course of a set of rejection
+    iterations, the residuals with respect to the model change. This method
+    resets the flags back to the base-level rejection (i.e., independent of
+    the model), allowing the rejection to be based on the most recent set of
+    parameters and potentially recovering good data that was previously
+    rejected because of a poor model fit.
+
+    .. warning::
+        The objects are *all* modified in place.
+
+    Args:
+        disk (:class:`~nirvana.models.axisym.AxisymmetricDisk`):
+            Object that performed the fit and has the best-fitting parameters.
+        kin (:class:`~nirvana.data.kinematics.Kinematics`):
+            Object with the data being fit.
+        vel_mask (`numpy.ndarray`_):
+            Bitmask used to track velocity rejections.
+        sig_mask (`numpy.ndarray`_):
+            Bitmask used to track dispersion rejections. Can be None.
+    """
+    # Turn off the relevant rejection for all pixels
+    vel_mask = disk.mbm.turn_off(vel_mask, flag='REJ_RESID')
+    # Reset the data mask held by the Kinematics object
+    kin.vel_mask = disk.mbm.flagged(vel_mask, flag=disk.mbm.base_flags())
+    if sig_mask is not None:
+        # Turn off the relevant rejection for all pixels
+        sig_mask = disk.mbm.turn_off(sig_mask, flag='REJ_RESID')
+        # Reset the data mask held by the Kinematics object
+        kin.sig_mask = disk.mbm.flagged(sig_mask, flag=disk.mbm.base_flags())
 
 
 def axisym_iter_fit(galmeta, kin, rctype='HyperbolicTangent', dctype='Exponential', fitdisp=True,
@@ -2089,12 +1933,12 @@ def axisym_iter_fit(galmeta, kin, rctype='HyperbolicTangent', dctype='Exponentia
     if rctype == 'HyperbolicTangent':
         # TODO: Maybe want to make the guess hrot based on the effective radius...
         p0 = np.append(p0, np.array([min(900., vproj), 1.]))
-        rc = HyperbolicTangent(lb=np.array([0., 1e-3]),
-                               ub=np.array([1000., max(5., kin.max_radius())]))
+        rc = oned.HyperbolicTangent(lb=np.array([0., 1e-3]),
+                                    ub=np.array([1000., max(5., kin.max_radius())]))
     elif rctype == 'PolyEx':
         p0 = np.append(p0, np.array([min(900., vproj), 1., 0.1]))
-        rc = PolyEx(lb=np.array([0., 1e-3, -1.]),
-                    ub=np.array([1000., max(5., kin.max_radius()), 1.]))
+        rc = oned.PolyEx(lb=np.array([0., 1e-3, -1.]),
+                         ub=np.array([1000., max(5., kin.max_radius()), 1.]))
     else:
         raise ValueError(f'Unknown RC parameterization: {rctype}')
 
@@ -2107,13 +1951,14 @@ def axisym_iter_fit(galmeta, kin, rctype='HyperbolicTangent', dctype='Exponentia
         # the dispersion e-folding length.
         if dctype == 'Exponential':
             p0 = np.append(p0, np.array([sig0, 2*galmeta.reff/1.7]))
-            dc = Exponential(lb=np.array([0., 1e-3]), ub=np.array([1000., 3*galmeta.reff]))
+            dc = oned.Exponential(lb=np.array([0., 1e-3]), ub=np.array([1000., 3*galmeta.reff]))
         elif dctype == 'ExpBase':
             p0 = np.append(p0, np.array([sig0, 2*galmeta.reff/1.7, 1.]))
-            dc = ExpBase(lb=np.array([0., 1e-3, 0.]), ub=np.array([1000., 3*galmeta.reff, 100.]))
+            dc = oned.ExpBase(lb=np.array([0., 1e-3, 0.]),
+                              ub=np.array([1000., 3*galmeta.reff, 100.]))
         elif dctype == 'Const':
             p0 = np.append(p0, np.array([sig0]))
-            dc = Const(lb=np.array([0.]), ub=np.array([1000.]))
+            dc = oned.Const(lb=np.array([0.]), ub=np.array([1000.]))
 
     # Report
     print(f'Rotation curve parameterization class: {rc.__class__.__name__}')
@@ -2237,19 +2082,16 @@ def axisym_iter_fit(galmeta, kin, rctype='HyperbolicTangent', dctype='Exponentia
     #     measurements are bogus.
     print('Running rejection iterations')
     vel_rej, vel_sig, sig_rej, sig_sig \
-            = disk_fit_reject(kin, disk, disp=fitdisp, ignore_covar=True,
-                              vel_mask=vel_mask, vel_sigma_rej=_vel_sigma_rej[0], show_vel=debug,
-                              sig_mask=sig_mask, sig_sigma_rej=_sig_sigma_rej[0], show_sig=debug,
-                              rej_flag='REJ_UNR', verbose=verbose > 1)
-
-#        # Incorporate into mask
-#        if vel_mask is not None and np.any(vel_rej):
-#            vel_mask[vel_rej] = disk.mbm.turn_on(vel_mask[vel_rej], rej_flag)
-
+            = disk.reject(disp=fitdisp, ignore_covar=True, vel_sigma_rej=_vel_sigma_rej[0],
+                          show_vel=debug, sig_sigma_rej=_sig_sigma_rej[0], show_sig=debug,
+                          verbose=verbose > 1)
+    if np.any(vel_rej):
+        print(f'{np.sum(vel_rej)} velocity measurements rejected as unreliable.')
+        vel_mask[vel_rej] = disk.mbm.turn_on(vel_mask[vel_rej], 'REJ_UNR')
+    if fitdisp and sig_rej is not None and np.any(sig_rej):
+        print(f'{np.sum(sig_rej)} dispersion measurements rejected as unreliable.')
+        sig_mask[sig_rej] = disk.mbm.turn_on(sig_mask[sig_rej], 'REJ_UNR')
     #   - Incorporate the rejection into the Kinematics object
-    print(f'Rejecting {0 if vel_rej is None else np.sum(vel_rej)} velocity measurements.')
-    if disk.dc is not None:
-        print(f'Rejecting {0 if sig_rej is None else np.sum(sig_rej)} dispersion measurements.')
     kin.reject(vel_rej=vel_rej, sig_rej=sig_rej)
     #   - Refit, again with the inclination and center fixed. However, do not
     #     use the parameters from the previous fit as the starting point, and
@@ -2267,14 +2109,16 @@ def axisym_iter_fit(galmeta, kin, rctype='HyperbolicTangent', dctype='Exponentia
     #   - Perform a more restricted rejection
     print('Running rejection iterations')
     vel_rej, vel_sig, sig_rej, sig_sig \
-            = disk_fit_reject(kin, disk, disp=fitdisp, ignore_covar=True,
-                              vel_mask=vel_mask, vel_sigma_rej=_vel_sigma_rej[1], show_vel=debug,
-                              sig_mask=sig_mask, sig_sigma_rej=_sig_sigma_rej[1], show_sig=debug,
-                              rej_flag='REJ_RESID', verbose=verbose > 1)
+            = disk.reject(disp=fitdisp, ignore_covar=True, vel_sigma_rej=_vel_sigma_rej[1],
+                          show_vel=debug, sig_sigma_rej=_sig_sigma_rej[1], show_sig=debug,
+                          verbose=verbose > 1)
+    if np.any(vel_rej):
+        print(f'{np.sum(vel_rej)} velocity measurements rejected due to large residuals.')
+        vel_mask[vel_rej] = disk.mbm.turn_on(vel_mask[vel_rej], 'REJ_RESID')
+    if fitdisp and sig_rej is not None and np.any(sig_rej):
+        print(f'{np.sum(sig_rej)} dispersion measurements rejected due to large residuals.')
+        sig_mask[sig_rej] = disk.mbm.turn_on(sig_mask[sig_rej], 'REJ_RESID')
     #   - Incorporate the rejection into the Kinematics object
-    print(f'Rejecting {0 if vel_rej is None else np.sum(vel_rej)} velocity measurements.')
-    if disk.dc is not None:
-        print(f'Rejecting {0 if sig_rej is None else np.sum(sig_rej)} dispersion measurements.')
     kin.reject(vel_rej=vel_rej, sig_rej=sig_rej)
     #   - Refit again with the inclination and center fixed, but use the
     #     previous fit as the starting point and include the estimated
@@ -2295,14 +2139,16 @@ def axisym_iter_fit(galmeta, kin, rctype='HyperbolicTangent', dctype='Exponentia
     #   - Reject again based on the new fit parameters
     print('Running rejection iterations')
     vel_rej, vel_sig, sig_rej, sig_sig \
-            = disk_fit_reject(kin, disk, disp=fitdisp, ignore_covar=True,
-                              vel_mask=vel_mask, vel_sigma_rej=_vel_sigma_rej[1], show_vel=debug,
-                              sig_mask=sig_mask, sig_sigma_rej=_sig_sigma_rej[1], show_sig=debug,
-                              rej_flag='REJ_RESID', verbose=verbose > 1)
+            = disk.reject(disp=fitdisp, ignore_covar=True, vel_sigma_rej=_vel_sigma_rej[1],
+                          show_vel=debug, sig_sigma_rej=_sig_sigma_rej[1], show_sig=debug,
+                          verbose=verbose > 1)
+    if np.any(vel_rej):
+        print(f'{np.sum(vel_rej)} velocity measurements rejected due to large residuals.')
+        vel_mask[vel_rej] = disk.mbm.turn_on(vel_mask[vel_rej], 'REJ_RESID')
+    if fitdisp and sig_rej is not None and np.any(sig_rej):
+        print(f'{np.sum(sig_rej)} dispersion measurements rejected due to large residuals.')
+        sig_mask[sig_rej] = disk.mbm.turn_on(sig_mask[sig_rej], 'REJ_RESID')
     #   - Incorporate the rejection into the Kinematics object
-    print(f'Rejecting {0 if vel_rej is None else np.sum(vel_rej)} velocity measurements.')
-    if disk.dc is not None:
-        print(f'Rejecting {0 if sig_rej is None else np.sum(sig_rej)} dispersion measurements.')
     kin.reject(vel_rej=vel_rej, sig_rej=sig_rej)
     #   - Refit again with the inclination and center fixed, but use the
     #     previous fit as the starting point and include the estimated
@@ -2323,14 +2169,16 @@ def axisym_iter_fit(galmeta, kin, rctype='HyperbolicTangent', dctype='Exponentia
     #   - Reject again based on the new fit parameters
     print('Running rejection iterations')
     vel_rej, vel_sig, sig_rej, sig_sig \
-            = disk_fit_reject(kin, disk, disp=fitdisp, ignore_covar=True,
-                              vel_mask=vel_mask, vel_sigma_rej=_vel_sigma_rej[2], show_vel=debug,
-                              sig_mask=sig_mask, sig_sigma_rej=_vel_sigma_rej[2], show_sig=debug,
-                              rej_flag='REJ_RESID', verbose=verbose > 1)
+            = disk.reject(disp=fitdisp, ignore_covar=True, vel_sigma_rej=_vel_sigma_rej[2],
+                          show_vel=debug, sig_sigma_rej=_sig_sigma_rej[2], show_sig=debug,
+                          verbose=verbose > 1)
+    if np.any(vel_rej):
+        print(f'{np.sum(vel_rej)} velocity measurements rejected due to large residuals.')
+        vel_mask[vel_rej] = disk.mbm.turn_on(vel_mask[vel_rej], 'REJ_RESID')
+    if fitdisp and sig_rej is not None and np.any(sig_rej):
+        print(f'{np.sum(sig_rej)} dispersion measurements rejected due to large residuals.')
+        sig_mask[sig_rej] = disk.mbm.turn_on(sig_mask[sig_rej], 'REJ_RESID')
     #   - Incorporate the rejection into the Kinematics object
-    print(f'Rejecting {0 if vel_rej is None else np.sum(vel_rej)} velocity measurements.')
-    if disk.dc is not None:
-        print(f'Rejecting {0 if sig_rej is None else np.sum(sig_rej)} dispersion measurements.')
     kin.reject(vel_rej=vel_rej, sig_rej=sig_rej)
     #   - Now fit as requested by the user, freeing one or both of the
     #     inclination and center. Use the previous fit as the starting point
@@ -2360,14 +2208,16 @@ def axisym_iter_fit(galmeta, kin, rctype='HyperbolicTangent', dctype='Exponentia
     # argument?
     print('Running rejection iterations')
     vel_rej, vel_sig, sig_rej, sig_sig \
-            = disk_fit_reject(kin, disk, disp=fitdisp, ignore_covar=ignore_covar,
-                              vel_mask=vel_mask, vel_sigma_rej=_vel_sigma_rej[3], show_vel=debug,
-                              sig_mask=sig_mask, sig_sigma_rej=_vel_sigma_rej[3], show_sig=debug,
-                              rej_flag='REJ_RESID', verbose=verbose > 1)
+            = disk.reject(disp=fitdisp, ignore_covar=ignore_covar, vel_sigma_rej=_vel_sigma_rej[3],
+                          show_vel=debug, sig_sigma_rej=_sig_sigma_rej[3], show_sig=debug,
+                          verbose=verbose > 1)
+    if np.any(vel_rej):
+        print(f'{np.sum(vel_rej)} velocity measurements rejected due to large residuals.')
+        vel_mask[vel_rej] = disk.mbm.turn_on(vel_mask[vel_rej], 'REJ_RESID')
+    if fitdisp and sig_rej is not None and np.any(sig_rej):
+        print(f'{np.sum(sig_rej)} dispersion measurements rejected due to large residuals.')
+        sig_mask[sig_rej] = disk.mbm.turn_on(sig_mask[sig_rej], 'REJ_RESID')
     #   - Incorporate the rejection into the Kinematics object
-    print(f'Rejecting {0 if vel_rej is None else np.sum(vel_rej)} velocity measurements.')
-    if disk.dc is not None:
-        print(f'Rejecting {0 if sig_rej is None else np.sum(sig_rej)} dispersion measurements.')
     kin.reject(vel_rej=vel_rej, sig_rej=sig_rej)
     #   - Redo previous fit
     print('Running fit iteration 6')

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -11,23 +11,23 @@ import warnings
 from IPython import embed
 
 import numpy as np
-from scipy import optimize
 from matplotlib import pyplot, rc, patches, ticker, colors
 
 from astropy.io import fits
 
 from .oned import HyperbolicTangent, Exponential, ExpBase, Const, PolyEx
 from .geometry import projected_polar, deriv_projected_polar
-from .beam import ConvolveFFTW, smear, deriv_smear
-from .util import cov_err
+from .beam import smear, deriv_smear
 from . import asymmetry
 from ..data.kinematics import Kinematics
 from ..data.scatter import IntrinsicScatter
-from ..data.util import impose_positive_definite, cinv, inverse, find_largest_coherent_region
+from ..data.util import inverse, find_largest_coherent_region
 from ..data.util import select_major_axis, bin_stats, growth_lim, atleast_one_decade
 from ..util.bitmask import BitMask
 from ..util import plot
 from ..util import fileio
+
+from .thindisk import ThinDisk
 
 #warnings.simplefilter('error', RuntimeWarning)
 
@@ -311,7 +311,7 @@ class AxisymmetricDiskGlobalBitMask(BitMask):
         super().__init__(mask_def[:,0], descr=mask_def[:,1])
 
 
-class AxisymmetricDisk:
+class AxisymmetricDisk(ThinDisk):
     r"""
     Simple model for an axisymmetric disk.
 
@@ -371,50 +371,20 @@ class AxisymmetricDisk:
         # Velocity dispersion curve (can be None)
         self.dc = dc
 
-        # Number of "base" parameters
-        self.nbp = 5
+        # Instantiate the base class, which basically keeps all of the geometric
+        # parameters.  NOTE: The parametric curves above need to be defined
+        # first because instatiation of the base class calls reinit(), which
+        # sets default guess parameters.  TODO: Consider instantiating without
+        # guess parameters...
+        super().__init__()
+
         # Total number parameters
         self.np = self.nbp + self.rc.np
         if self.dc is not None:
             self.np += self.dc.np
-        # Initialize the parameters (see reinit function)
-        self.par_err = None
         # Flag which parameters are freely fit
         self.free = np.ones(self.np, dtype=bool)
         self.nfree = np.sum(self.free)
-        # This call to reinit adds the workspace attributes
-        self.reinit()
-
-    def __repr__(self):
-        """
-        Provide the representation of the object when written to the screen.
-        """
-        # Collect the attributes relevant to construction of a model
-        attr = [n for n in ['par', 'x', 'y', 'sb', 'beam_fft'] if getattr(self, n) is not None]
-        return f'<{self.__class__.__name__}: Defined attr - {",".join(attr)}>'
-
-    def reinit(self):
-        """
-        Reinitialize the object.
-
-        This resets the model parameters to the guess parameters and erases any
-        existing data used to construct the models.  Note that, just like when
-        instantiating a new object, any calls to :func:`model` after
-        reinitialization will require at least the coordinates (``x`` and ``y``)
-        to be provided to successfully calculate the model.
-        """
-        self.par = self.guess_par()
-        self.x = None
-        self.y = None
-        self.beam_fft = None
-        self.kin = None
-        self.sb = None
-        self.vel_gpm = None
-        self.sig_gpm = None
-        self.cnvfftw = None
-        self.global_mask = 0
-        self.fit_status = None
-        self.fit_success = None
 
     def guess_par(self):
         """
@@ -427,8 +397,7 @@ class AxisymmetricDisk:
         Returns:
             `numpy.ndarray`_: Vector of guess parameters
         """
-        # Return the 
-        gp = np.concatenate(([0., 0., 45., 30., 0.], self.rc.guess_par()))
+        gp = np.concatenate((super().guess_par(), self.rc.guess_par()))
         return gp if self.dc is None else np.append(gp, self.dc.guess_par())
 
     def par_names(self, short=False):
@@ -442,31 +411,22 @@ class AxisymmetricDisk:
         Returns:
             :obj:`list`: List of parameter name strings.
         """
+        base = super().par_names(short=short)
         if short:
-            base = ['x0', 'y0', 'pa', 'inc', 'vsys']
             rc = [f'v_{p}' for p in self.rc.par_names(short=True)]
             dc = [] if self.dc is None else [f's_{p}' for p in self.dc.par_names(short=True)]
         else:
-            base = ['X center', 'Y center', 'Position Angle', 'Inclination', 'Systemic Velocity']
             rc = [f'RC: {p}' for p in self.rc.par_names()]
             dc = [] if self.dc is None else [f'Disp: {p}' for p in self.dc.par_names()]
         return base + rc + dc
 
-    def base_par(self, err=False):
-        """
-        Return the base (largely geometric) parameters. Returns None if
-        parameters are not defined yet.
-
-        Args:
-            err (:obj:`bool`, optional):
-                Return the parameter errors instead of the parameter values.
-
-        Returns:
-            `numpy.ndarray`_: Vector with parameters or parameter errors for the
-            "base" parameters.
-        """
-        p = self.par_err if err else self.par
-        return None if p is None else p[:self.nbp]
+    # These "private" functions yield slices of the parameter vector for the
+    # desired set of parameters
+    def _rc_slice(self):
+        return slice(self.nbp, self.nbp + self.rc.np)
+    def _dc_slice(self):
+        s = self.nbp + self.rc.np
+        return slice(s, s + self.dc.np)
 
     def rc_par(self, err=False):
         """
@@ -482,7 +442,7 @@ class AxisymmetricDisk:
             rotation curve.
         """
         p = self.par_err if err else self.par
-        return None if p is None else p[self.nbp:self.nbp+self.rc.np]
+        return None if p is None else p[self._rc_slice()]
 
     def dc_par(self, err=False):
         """
@@ -498,7 +458,7 @@ class AxisymmetricDisk:
             dispersion profile.
         """
         p = self.par_err if err else self.par
-        return None if p is None or self.dc is None else p[self.nbp+self.rc.np:]
+        return None if p is None or self.dc is None else p[self._dc_slice()]
 
     def par_bounds(self, base_lb=None, base_ub=None):
         """
@@ -525,201 +485,12 @@ class AxisymmetricDisk:
             :obj:`tuple`: A two-tuple providing, respectively, the lower and
             upper boundaries for all model parameters.
         """
-        if base_lb is not None and len(base_lb) != self.nbp:
-            raise ValueError('Incorrect number of lower bounds for the base '
-                             f'parameters; found {len(base_lb)}, expected {self.nbp}.')
-        if base_ub is not None and len(base_ub) != self.nbp:
-            raise ValueError('Incorrect number of upper bounds for the base '
-                             f'parameters; found {len(base_ub)}, expected {self.nbp}.')
-
-        if (base_lb is None or base_ub is None) and (self.x is None or self.y is None):
-            raise ValueError('Cannot define limits on center.  Provide base_lb,base_ub or set '
-                             'the evaluation grid coordinates (attributes x and y).')
-
-        if base_lb is None:
-            minx = np.amin(self.x)
-            miny = np.amin(self.y)
-            base_lb = np.array([minx, miny, -350., 1., -300.])
-        if base_ub is None:
-            maxx = np.amax(self.x)
-            maxy = np.amax(self.y)
-            base_ub = np.array([maxx, maxy, 350., 89., 300.])
+        _base_lb, _base_ub = super().par_bounds(base_lb=base_lb, base_ub=base_ub)
         # Minimum and maximum allowed values for xc, yc, pa, inc, vsys, vrot, hrot
-        lb = np.concatenate((base_lb, self.rc.lb))
-        ub = np.concatenate((base_ub, self.rc.ub))
+        lb = np.concatenate((_base_lb, self.rc.lb))
+        ub = np.concatenate((_base_ub, self.rc.ub))
         return (lb, ub) if self.dc is None \
                     else (np.append(lb, self.dc.lb), np.append(ub, self.dc.ub))
-
-    def _set_par(self, par):
-        """
-        Set the full parameter vector, accounting for any fixed parameters.
-
-        Args:
-            par (`numpy.ndarray`_, optional):
-                The list of parameters to use. Length should be either
-                :attr:`np` or :attr:`nfree`. If the latter, the values of the
-                fixed parameters in :attr:`par` are used.
-        """
-        if par.ndim != 1:
-            raise ValueError('Parameter array must be a 1D vector.')
-        if par.size == self.np:
-            self.par = par.copy()
-            return
-        if par.size != self.nfree:
-            raise ValueError('Must provide {0} or {1} parameters.'.format(self.np, self.nfree))
-        self.par[self.free] = par.copy()
-
-    def _init_coo(self, x, y):
-        """
-        Initialize the coordinate arrays.
-
-        .. warning::
-            
-            Input coordinate data types are all converted to `numpy.float64`_.
-            This is always true, even though this is only needed when using
-            :class:`~nirvana.models.beam.ConvolveFFTW`.
-
-        Args:
-            x (`numpy.ndarray`_):
-                The 2D x-coordinates at which to evaluate the model.  If not
-                None, replace the existing :attr:`x` with this array.
-            y (`numpy.ndarray`_):
-                The 2D y-coordinates at which to evaluate the model.  If not
-                None, replace the existing :attr:`y` with this array.
-
-        Raises:
-            ValueError:
-                Raised if the shapes of :attr:`x` and :attr:`y` are not the same.
-        """
-        if x is None and y is None:
-            # Nothing to do
-            return
-
-        # Define it and check it
-        if x is not None:
-            self.x = x.astype(float)
-        if y is not None:
-            self.y = y.astype(float)
-        if self.x.shape != self.y.shape:
-            raise ValueError('Input coordinates must have the same shape.')
-
-    def _init_sb(self, sb):
-        """
-        Initialize the surface brightness array.
-
-        .. warning::
-            
-            Input surface-brightness data types are all converted to
-            `numpy.float64`_.  This is always true, even though this is only
-            needed when using :class:`~nirvana.models.beam.ConvolveFFTW`.
-
-        Args:
-            sb (`numpy.ndarray`_):
-                2D array with the surface brightness of the object.  If not
-                None, replace the existing :attr:`sb` with this array.
-
-        Raises:
-            ValueError:
-                Raised if the shapes of :attr:`sb` and :attr:`x` are not the same.
-        """
-        if sb is None:
-            # Nothing to do
-            return
-
-        # Check it makes sense to define the surface brightness
-        if self.x is None:
-            raise ValueError('Input coordinates must be instantiated first!')
-
-        # Define it and check it
-        self.sb = sb.astype(float)
-        if self.sb.shape != self.x.shape:
-            raise ValueError('Input coordinates must have the same shape.')
-
-    def _init_beam(self, beam, is_fft, cnvfftw):
-        """
-        Initialize the beam-smearing kernel and the convolution method.
-
-        Args:
-            beam (`numpy.ndarray`_):
-                The 2D rendering of the beam-smearing kernel, or its Fast
-                Fourier Transform (FFT).  If not None, replace existing
-                :attr:`beam_fft` with this array (or its FFT, depending on the
-                provided ``is_fft``).
-            is_fft (:obj:`bool`):
-                The provided ``beam`` object is already the FFT of the
-                beam-smearing kernel.
-            cnvfftw (:class:`~nirvana.models.beam.ConvolveFFTW`):
-                An object that expedites the convolutions using FFTW/pyFFTW.  If
-                provided, the shape *must* match :attr:``beam_fft`` (after this
-                is potentially updated by the provided ``beam``).  If None, a
-                new :class:`~nirvana.models.beam.ConvolveFFTW` instance is
-                constructed to perform the convolutions.  If the class cannot be
-                constructed because the user doesn't have pyfftw installed, then
-                the convolutions fall back to the numpy routines.
-        """
-        if beam is None:
-            # Nothing to do
-            return
-
-        # Check it makes sense to define the beam
-        if self.x is None:
-            raise ValueError('Input coordinates must be instantiated first!')
-        if self.x.ndim != 2:
-            raise ValueError('To perform convolution, must provide 2d coordinate arrays.')
-
-        # Assign the beam and check it
-        self.beam_fft = beam if is_fft else np.fft.fftn(np.fft.ifftshift(beam))
-        if self.beam_fft.shape != self.x.shape:
-            raise ValueError('Currently, convolution requires the beam map to have the same '
-                                'shape as the coordinate maps.')
-
-        # Convolutions will be performed, try to setup the ConvolveFFTW
-        # object (self.cnvfftw).
-        if cnvfftw is None:
-            if self.cnvfftw is not None and self.cnvfftw.shape == self.beam_fft.shape:
-                # ConvolveFFTW is ready to go
-                return
-
-            try:
-                self.cnvfftw = ConvolveFFTW(self.beam_fft.shape)
-            except:
-                warnings.warn('Could not instantiate ConvolveFFTW; proceeding with numpy '
-                              'FFT/convolution routines.')
-                self.cnvfftw = None
-        else:
-            # A cnvfftw was provided, check it
-            if not isinstance(cnvfftw, ConvolveFFTW):
-                raise TypeError('Provided cnvfftw must be a ConvolveFFTW instance.')
-            if cnvfftw.shape != self.beam_fft.shape:
-                raise ValueError('cnvfftw shape does not match beam shape.')
-            self.cnvfftw = cnvfftw
-
-    def _init_par(self, p0, fix):
-        """
-        Initialize the relevant parameter vectors that tracks the full set of
-        model parameters and which of those are freely fit by the model.
-
-        Args:
-            p0 (`numpy.ndarray`_):
-                The initial parameters for the model.  Can be None.  Length must
-                be :attr:`np`, if not None.
-            fix (`numpy.ndarray`_):
-                A boolean array selecting the parameters that should be fixed
-                during the model fit.  Can be None.  Length must be :attr:`np`,
-                if not None.
-        """
-        if p0 is None:
-            p0 = self.guess_par()
-        _p0 = np.atleast_1d(p0)
-        if _p0.size != self.np:
-            raise ValueError('Incorrect number of model parameters.')
-        self.par = _p0.copy()
-        self.par_err = None
-        _free = np.ones(self.np, dtype=bool) if fix is None else np.logical_not(fix)
-        if _free.size != self.np:
-            raise ValueError('Incorrect number of model parameter fitting flags.')
-        self.free = _free.copy()
-        self.nfree = np.sum(self.free)
 
     def model(self, par=None, x=None, y=None, sb=None, beam=None, is_fft=False, cnvfftw=None,
               ignore_beam=False):
@@ -781,31 +552,17 @@ class AxisymmetricDisk:
             `numpy.ndarray`_, :obj:`tuple`: The velocity field model, and the
             velocity dispersion field model, if the latter is included
         """
-        # Initialize the coordinates (this does nothing if both x and y are None)
-        self._init_coo(x, y)
-        # Initialize the surface brightness (this does nothing if sb is None)
-        self._init_sb(sb)
-        # Initialize the convolution kernel (this does nothing if beam is None)
-        self._init_beam(beam, is_fft, cnvfftw)
-        if self.beam_fft is not None and not ignore_beam:
-            # Initialize the surface brightness, only if it would be used
-            self._init_sb(sb)
-        # Check that the model can be calculated
-        if self.x is None or self.y is None:
-            raise ValueError('No coordinate grid defined.')
-        # Reset the parameter values
-        if par is not None:
-            self._set_par(par)
+        # Initialize the thin disk model
+        self._init_model(par, x, y, sb, beam, is_fft, cnvfftw, ignore_beam)
 
+        # Calculate the in-disk coordinates
         r, theta = projected_polar(self.x - self.par[0], self.y - self.par[1],
                                    *np.radians(self.par[2:4]))
 
         # NOTE: The velocity-field construction does not include the
         # sin(inclination) term because this is absorbed into the
         # rotation curve amplitude.
-        ps = self.nbp
-        pe = ps + self.rc.np
-        vel = self.rc.sample(r, par=self.par[ps:pe])*np.cos(theta) + self.par[4]
+        vel = self.rc.sample(r, par=self.par[self._rc_slice()])*np.cos(theta) + self.par[4]
         if self.dc is None:
             # Only fitting the velocity field
             return vel if self.beam_fft is None or ignore_beam \
@@ -813,9 +570,7 @@ class AxisymmetricDisk:
                                    cnvfftw=self.cnvfftw)[1]
 
         # Fitting both the velocity and velocity-dispersion field
-        ps = pe
-        pe = ps + self.dc.np
-        sig = self.dc.sample(r, par=self.par[ps:pe])
+        sig = self.dc.sample(r, par=self.par[self._dc_slice()])
         return (vel, sig) if self.beam_fft is None or ignore_beam \
                         else smear(vel, self.beam_fft, beam_fft=True, sb=self.sb, sig=sig,
                                    cnvfftw=self.cnvfftw)[1:]
@@ -880,21 +635,8 @@ class AxisymmetricDisk:
             `numpy.ndarray`_, :obj:`tuple`: The velocity field model, and the
             velocity dispersion field model, if the latter is included
         """
-        # Initialize the coordinates (this does nothing if both x and y are None)
-        self._init_coo(x, y)
-        # Initialize the surface brightness (this does nothing if sb is None)
-        self._init_sb(sb)
-        # Initialize the convolution kernel (this does nothing if beam is None)
-        self._init_beam(beam, is_fft, cnvfftw)
-        if self.beam_fft is not None and not ignore_beam:
-            # Initialize the surface brightness, only if it would be used
-            self._init_sb(sb)
-        # Check that the model can be calculated
-        if self.x is None or self.y is None:
-            raise ValueError('No coordinate grid defined.')
-        # Reset the parameter values
-        if par is not None:
-            self._set_par(par)
+        # Initialize the thin disk model
+        self._init_model(par, x, y, sb, beam, is_fft, cnvfftw, ignore_beam)
 
         # Initialize the derivative arrays needed for the coordinate calculation
         dx = np.zeros(self.x.shape+(self.np,), dtype=float)
@@ -915,14 +657,11 @@ class AxisymmetricDisk:
         # sin(inclination) term because this is absorbed into the
         # rotation curve amplitude.
 
-        # Get the parameter index range
-        ps = self.nbp
-        pe = ps + self.rc.np
-
         # Calculate the rotation speed and its parameter derivatives
+        slc = self._rc_slice()
         dvrot = np.zeros(self.x.shape+(self.np,), dtype=float)
-        vrot, dvrot[...,ps:pe] = self.rc.deriv_sample(r, par=self.par[ps:pe])
-        dvrot += self.rc.ddx(r, par=self.par[ps:pe])[...,None]*dr
+        vrot, dvrot[...,slc] = self.rc.deriv_sample(r, par=self.par[slc])
+        dvrot += self.rc.ddx(r, par=self.par[slc])[...,None]*dr
 
         # Calculate the line-of-sight velocity and its parameter derivatives
         cost = np.cos(theta)
@@ -942,14 +681,11 @@ class AxisymmetricDisk:
 
         # Fitting both the velocity and velocity-dispersion field
 
-        # Get the parameter index range
-        ps = pe
-        pe = ps + self.dc.np
-
         # Calculate the dispersion profile and its parameter derivatives
+        slc = self._dc_slice()
         dsig = np.zeros(self.x.shape+(self.np,), dtype=float)
-        sig, dsig[...,ps:pe] = self.dc.deriv_sample(r, par=self.par[ps:pe])
-        dsig += self.dc.ddx(r, par=self.par[ps:pe])[...,None]*dr
+        sig, dsig[...,slc] = self.dc.deriv_sample(r, par=self.par[slc])
+        dsig += self.dc.ddx(r, par=self.par[slc])[...,None]*dr
 
         if self.beam_fft is None or ignore_beam:
             # Not smearing
@@ -959,850 +695,6 @@ class AxisymmetricDisk:
         _, v, sig, _, dv, dsig = deriv_smear(v, dv, self.beam_fft, beam_fft=True, sb=self.sb,
                                              sig=sig, dsig=dsig, cnvfftw=self.cnvfftw)
         return v, sig, dv, dsig
-
-    def mock_observation(self, par, kin=None, x=None, y=None, sb=None, binid=None,
-                         vel_ivar=None, vel_covar=None, vel_mask=None, sig_ivar=None,
-                         sig_covar=None, sig_mask=None, sig_corr=None, beam=None, is_fft=False,
-                         cnvfftw=None, ignore_beam=False, add_err=False, positive_definite=False,
-                         rng=None):
-        r"""
-        Construct a mock observation.
-
-        The mock data can be defined in one of two ways:
-
-            #. If a :class:`~nirvana.data.kinematics.Kinematics` object is
-               provided using the ``kin`` keyword, all other keyword arguments
-               are ignored and the mock data are meant to explicitly mimic the
-               real observations.
-
-            #. Otherwise, most of the other keywords are used to instantiate a
-               mock :class:`~nirvana.data.kinematics.Kinematics` object.  Just
-               like when instantiating a
-               :class:`~nirvana.data.kinematics.Kinematics` object, the provided
-               data arrays *must* be 2D and all have the same shape.
-
-        The mock observation is constructed by sampling the model exactly as
-        done when fitting real observations.  If errors are provided and
-        ``add_err`` is True, Gaussian error is added to the model values.
-
-        .. warning::
-
-            - Unlike :func:`model`, this method does *not* use any pre-existing
-              attributes in place of keyword arguments that are not directly
-              provided.  For example, if ``beam`` is None on input,
-              :attr:`beam_fft` will *not* be used even if available.  Instead,
-              this method calls :func:`reinit` to reinitialize the object such
-              that the mock observation is built from the provided arguments
-              only.
-
-            - Covariance matrices are expected to be positive-definite on input!
-
-            - When adding error, masked elements are ignored (i.e., no error is
-              added to them).
-
-        Args:
-            par (array-like):
-                The list of model parameters to use. Length must be :attr:`np`.
-            kin (:class:`~nirvana.data.kinematics.Kinematics`, optional):
-                Object with the kinematic data to mimic.  If None, must provide
-                at least ``x``, ``y``, and ``vel_ivar``.
-            x (`numpy.ndarray`_, optional):
-                The 2D x-coordinates at which to evaluate the model. Ignored if
-                ``kin`` is provided.
-            y (`numpy.ndarray`_, optional):
-                The 2D y-coordinates at which to evaluate the model.  Shape must
-                match ``x``.  Ignored if ``kin`` is provided.  
-            sb (`numpy.ndarray`_, optional):
-                2D array with the (nominally unbinned) surface brightness of the
-                object. This is used to weight the convolution of the kinematic
-                fields according to the luminosity distribution of the object.
-                Must have the same shape as ``x``. If None, the convolution is
-                unweighted.  If a convolution is not performed (``beam`` is None
-                or ``ignore_beam`` is True) or if ``kin`` is provided, this
-                array is ignored.
-            binid (`numpy.ndarray`_, optional):
-                2D integer array associating each measurement with a unique bin
-                ID number. Measurements not associated with any bin should have
-                a value of -1 in this array. If None, all unmasked measurements
-                (see ``vel_mask`` and ``sig_mask``) are considered unique.
-                Shape must match ``x``.  Ignored if ``kin`` is provided.
-            vel_ivar (`numpy.ndarray`_, `numpy.ma.MaskedArray`_, optional):
-                2D array with the inverse variance of the velocity measurements.
-                If both this and ``vel_covar`` are None, no errors are added to
-                the model data.  Shape must match ``x``, and all array elements
-                with the same bin ID should have the same value.  If both
-                ``vel_ivar`` and ``vel_covar`` are provided, the latter takes
-                precedence.  Ignored if ``kin`` is provided.
-            vel_covar (`numpy.ndarray`_, `scipy.sparse.csr_matrix`_):
-                Covariance matrix for the velocity measurements.  If both this
-                and ``vel_ivar`` are None, no errors are added to the model
-                data.  The array must be square, where the length along one side
-                matches the number elements in ``x``.  If both ``vel_ivar`` and
-                ``vel_covar`` are provided, the latter takes precedence.
-                Ignored if ``kin`` is provided.
-            vel_mask (`numpy.ndarray`_, optional):
-                2D boolean array with a bad-pixel mask for the velocity
-                measurements (a mask value of True is ignored).  If None, all
-                velocity values are considered valid.  Shape must match ``x``.
-                If ``vel_ivar`` is a `numpy.ma.MaskedArray`_, this mask is
-                *combined* with ``vel_ivar.mask``.  Ignored if ``kin`` is
-                provided.
-            sig_ivar (`numpy.ndarray`_, `numpy.ma.MaskedArray`_, optional):
-                2D array with the inverse variance of the velocity dispersion
-                measurements.  If ``kin`` is provided or no velocity dispersion
-                parameterization is defined (i.e., :attr:`dc` is None), this is
-                ignored.  If both this and ``sig_covar`` are None, no errors are
-                added to the model data.  Shape must match ``x``, and all array
-                elements with the same bin ID should have the same value.  If
-                both ``sig_ivar`` and ``sig_covar`` are provided, the latter
-                takes precedence.
-            sig_covar (`numpy.ndarray`_, `scipy.sparse.csr_matrix`_):
-                Covariance matrix for the velocity dispersion measurements.  If
-                ``kin`` is provided or no velocity dispersion parameterization
-                is defined (i.e., :attr:`dc` is None), this is ignored.  If both
-                this and ``sig_ivar`` are None, no errors are added to the model
-                data.  The array must be square, where the length along one side
-                matches the number elements in ``x``.  If both ``sig_ivar`` and
-                ``sig_covar`` are provided, the latter takes precedence.
-            sig_mask (`numpy.ndarray`_, optional):
-                2D boolean array with a bad-pixel mask for the velocity
-                dispersion measurements (a mask value of True is ignored).  If
-                ``kin`` is provided or no velocity dispersion parameterization
-                is defined (i.e., :attr:`dc` is None), this is ignored.  If
-                None, all velocity dispersion values are considered valid.
-                Shape must match ``x``.  If ``sig_ivar`` is a
-                `numpy.ma.MaskedArray`_, this mask is *combined* with
-                ``sig_ivar.mask``.
-            sig_corr (`numpy.ndarray`_, optional):
-                A quadrature correction for the velocity dispersion
-                measurements. If None, velocity dispersions are assumed to be
-                the *astrophysical* Doppler broadening of the kinematic tracer.
-                If provided, the observed velocity dispersion used to construct
-                the mock :class:`~nirvana.data.kinematics.Kinematics` object is:
-
-                .. math::
-                    \sigma_{\rm obs}^2 = \sigma^2 + \sigma_{\rm corr}^2,
-
-                where the model is used to calculate :math:`\sigma`.
-            beam (`numpy.ndarray`_, optional):
-                The 2D rendering of the beam-smearing kernel, or its Fast
-                Fourier Transform (FFT).  If ``kin`` is provided, this is
-                ignored.  If not provided, no beam convolution is performed when
-                constructing the mock observations.
-            is_fft (:obj:`bool`, optional):
-                The provided ``beam`` object is already the FFT of the
-                beam-smearing kernel.  Ignored if ``kin`` is provided or
-                ``beam`` is not provided.
-            cnvfftw (:class:`~nirvana.models.beam.ConvolveFFTW`, optional):
-                An object that expedites the convolutions using
-                FFTW/pyFFTW. If None, the convolution is done using numpy
-                FFT routines.
-            ignore_beam (:obj:`bool`, optional):
-                Regardless of the availability of the beam profile, ignore it
-                and do not include it in the returned object.
-            add_err (:obj:`bool`, optional):
-                If provided by either ``kin`` or the method keyword arguments,
-                use the error distributions to add error to the mock model data.
-                Nominally, error should be added to mock observations, but it's
-                more efficient to create a noiseless dataset and then create
-                many noise realizations (see
-                :func:`~nirvana.data.kinematics.Kinematics.deviate`).  This
-                keyword only results in a single noise realization.
-            rng (`numpy.random.Generator`, optional):
-                Generator object to use.  If None, a new Generator is
-                instantiated; see :func:`~nirvana.data.util.gaussian_deviates`.
-
-        Returns:
-            :class:`~nirvana.data.kinematics.Kinematics`:  Object providing the
-            mock observations.  This object can be fit, e.g., with
-            :func:`lsq_fit`, as would be done with real observations.
-        """
-
-        # Get the input errors.  This is done first for the checks that follow.
-        if kin is None:
-            _vel_ivar = vel_ivar
-            _vel_covar = vel_covar
-            _sig_ivar = sig_ivar
-            _sig_covar = sig_covar
-        else:
-            _vel_ivar = None if kin.vel_ivar is None \
-                        else kin.remap('vel_ivar', masked=False, fill_value=0.)
-            _vel_covar = None if kin.vel_covar is None else kin.remap_covar('vel_covar')
-            _sig_ivar = None if self.dc is None or kin.sig_ivar is None \
-                        else kin.remap('sig_ivar', masked=False, fill_value=0.)
-            _sig_covar = None if self.dc is None or kin.sig_covar is None \
-                            else kin.remap_covar('sig_covar')
-
-        if add_err:
-            # Check: Dispersion model not defined but error and mask provided
-            if self.dc is None and any([s is not None for s in [_sig_ivar, _sig_covar, _sig_mask]]):
-                warnings.warn('AxisymmetricDisk instance does not include dispersion profile '
-                                'model.  Ignoring provided dispersion errors and mask.')
-            # Check: Dispersion model available and mismatch between availability of errors
-            if self.dc is not None and (_vel_ivar is not None and _sig_ivar is None \
-                                        or _vel_ivar is None and _sig_ivar is not None \
-                                        or _vel_covar is not None and _sig_covar is None \
-                                        or _vel_covar is None and _sig_covar is not None):
-                raise ValueError('When adding error, must add error to both vel and sigma.')
-
-        # Instantiate the mock Kinematics object
-        if kin is None:
-            # Revert the fft to get the spatial representation of the beam profile
-            _beam = None if beam is None or ignore_beam \
-                        else (np.fft.fftshift(np.fft.ifftn(beam).real) if is_fft else beam)
-
-            vel = np.zeros(x.shape, dtype=float)
-            sig = None if self.dc is None else np.zeros(x.shape, dtype=float)
-            _kin = Kinematics(vel, vel_ivar=_vel_ivar, vel_mask=vel_mask, vel_covar=_vel_covar,
-                              x=x, y=y, sb=sb, sig=sig, sig_ivar=_sig_ivar, sig_mask=sig_mask,
-                              sig_covar=_sig_covar, sig_corr=sig_corr, psf=_beam, binid=binid,
-                              grid_x=x, grid_y=y, grid_sb=sb, positive_definite=positive_definite)
-        else:
-            _kin = kin.copy()
-
-        # Reinitialize
-        self.reinit()
-
-        # TODO: Should rename the "_fit_prep" function!!
-        # Initialize internals for generating models.  Set "ignore_covar" to
-        # true because the handling of the covariance in the _fit_prep function
-        # is not needed here.
-        #                         fix, scat, sb_wgt, posdef, ignore_covar
-        self._fit_prep(_kin, par, None, None, True, True, True, cnvfftw)
-
-        # Generate and bin the model data.  NOTE: Call above to _fit_prep sets
-        # _kin to self.kin, which is used by _binned_model...
-        _kin.vel, _sig = self._binned_model(par)
-        # If available, include the dispersion correction
-        if _kin.sig_corr is not None:
-            _sig = np.sqrt(_sig**2 + _kin.sig_corr**2)
-
-        # Set whether or not to add Gaussian noise
-        if not add_err or _vel_ivar is None and _vel_covar is None:
-            _kin.update_sigma(sig=_sig)
-            return _kin
-
-        # Get the deviates
-        sigma_method = 'ignore' if self.dc is None else 'draw' 
-        vgpm, dv, sgpm, ds = _kin.deviate(sigma=sigma_method, rng=rng)
-        # Add the velocity error
-        _kin.vel[vgpm] += dv
-        # Add the dispersion error and update the dispersion values
-        if self.dc is not None:
-            _sig[sgpm] += ds
-            _kin.update_sigma(sig=_sig)
-
-        return _kin
-
-    def fisher_matrix(self, par, kin, fix=None, sb_wgt=False, scatter=None,
-                      assume_posdef_covar=False, ignore_covar=True, cnvfftw=None,
-                      inverse=False):
-        r"""
-        Construct the Fisher Information Matrix (FIM) at a specific position in
-        parameter space for a set of observational constraints.
-
-        The FIM is calculated using the derivatives of the fit metric with
-        respect to the model parameters (the Jacobian), just as done during the
-        least-squares minimization.  The shape of the Jacobian is :math:`(N,M)`,
-        where :math:`N` is the number of data points and :math:`M` is the number
-        of model parameters.  The FIM, :math:`\mathbf{I}(\theta)`, is the
-        :math:`(M,M)` matrix defined as:
-
-        .. math::
-
-            \mathbf{I}(\theta) = \mathbf{J}^T \mathbf{J}
-
-        Importantly, the Jacobian and the FIM are both *independent of the
-        measurements*, but not independent of the statistical uncertainties in
-        those measurements.
-
-        .. warning::
-
-            Currently, this class *does not construct a model of the
-            surface-brightness distribution*.  Instead, any weighting of the
-            model during convolution with the beam profile uses the as-observed
-            surface-brightness distribution, instead of a model of the intrinsic
-            surface brightness distribution.  See ``sb_wgt``.
-
-        Args:
-            par (array-like):
-                The list of model parameters at which to calculate the FIM.
-                I.e., the FIM is dependent on the position in parameter space.
-                Length must be :attr:`np`.
-            kin (:class:`~nirvana.data.kinematics.Kinematics`):
-                Object with the kinematic data.  This provides the measurement
-                uncertainties needed for the construction of the FIM, and it
-                also provides the grid on which to compute the model, the
-                surface-brightness weighting, the beam-smearing kernel, and the
-                binning function.
-            fix (`numpy.ndarray`_, optional):
-                A boolean array selecting the parameters that are fixed.  These
-                parameters are excluded from the FIM.
-            sb_wgt (:obj:`bool`, optional):
-                Flag to use the surface-brightness data provided by ``kin`` to
-                weight the model when applying the beam-smearing.  **See the
-                warning above**.
-            scatter (:obj:`float`, array-like, optional):
-                Introduce a fixed intrinsic-scatter term into the model. The 
-                scatter is added in quadrature to all measurement errors in the
-                calculation of the merit function. If no errors are available,
-                this has the effect of renormalizing the unweighted merit
-                function by 1/scatter.  Can be None, which means no intrinsic
-                scatter is added.  If both velocity and velocity dispersion are
-                being fit, this can be a single number applied to both datasets
-                or a 2-element vector that provides different intrinsic scatter
-                measurements for each kinematic moment (ordered velocity then
-                velocity dispersion).
-            assume_posdef_covar (:obj:`bool`, optional):
-                If the :class:`~nirvana.data.kinematics.Kinematics` include
-                covariance matrices, this forces the code to proceed assuming
-                the matrices are positive definite.
-            ignore_covar (:obj:`bool`, optional):
-                If the :class:`~nirvana.data.kinematics.Kinematics` include
-                covariance matrices, ignore them and just use the inverse
-                variance.
-            cnvfftw (:class:`~nirvana.models.beam.ConvolveFFTW`, optional):
-                An object that expedites the convolutions using FFTW/pyFFTW.  If
-                provided, the shape *must* match ``kin.spatial_shape``.  If
-                None, a new :class:`~nirvana.models.beam.ConvolveFFTW` instance
-                is constructed to perform the convolutions.  If the class cannot
-                be constructed because the user doesn't have pyfftw installed,
-                then the convolutions fall back to numpy routines.
-            inverse (:obj:`bool`, optional):
-                Return the inverse of the FIM, which is equivalent to the
-                covariance matrix in the model parameters.
-
-        Returns:
-            `numpy.ndarray`_: The :math:`(M,M)` Fisher Information Matrix, or
-            its inverse, at the selected position in parameter space.
-        """
-        self._fit_prep(kin, par, fix, scatter, sb_wgt, assume_posdef_covar, ignore_covar,
-                       cnvfftw)
-        jac = self._get_jac()(self.par[self.free])
-        return cov_err(jac) if inverse else np.dot(jac.T,jac)
-
-    # This slew of "private" functions consolidate the velocity residual and
-    # chi-square calculations
-    def _v_resid(self, vel):
-        return self.kin.vel[self.vel_gpm] - vel[self.vel_gpm]
-    def _deriv_v_resid(self, dvel):
-        return -dvel[np.ix_(self.vel_gpm, self.free)]
-    def _v_chisqr(self, vel):
-        return self._v_resid(vel) / self._v_err[self.vel_gpm]
-    def _deriv_v_chisqr(self, dvel):
-        return self._deriv_v_resid(dvel) / self._v_err[self.vel_gpm, None]
-    def _v_chisqr_covar(self, vel):
-        return np.dot(self._v_resid(vel), self._v_ucov)
-    def _deriv_v_chisqr_covar(self, dvel):
-        return np.dot(self._deriv_v_resid(dvel).T, self._v_ucov).T
-
-    # This slew of "private" functions consolidate the velocity dispersion
-    # residual and chi-square calculations
-    def _s_resid(self, sig):
-        return self.kin.sig_phys2[self.sig_gpm] - sig[self.sig_gpm]**2
-    def _deriv_s_resid(self, sig, dsig):
-        return -2 * sig[self.sig_gpm,None] * dsig[np.ix_(self.sig_gpm, self.free)]
-    def _s_chisqr(self, sig):
-        return self._s_resid(sig) / self._s_err[self.sig_gpm]
-    def _deriv_s_chisqr(self, sig, dsig):
-        return self._deriv_s_resid(sig, dsig) / self._s_err[self.sig_gpm, None]
-    def _s_chisqr_covar(self, sig):
-        return np.dot(self._s_resid(sig), self._s_ucov)
-    def _deriv_s_chisqr_covar(self, sig, dsig):
-        return np.dot(self._deriv_s_resid(sig, dsig).T, self._s_ucov).T
-
-    def _binned_model(self, par):
-        """
-        Compute the binned model data.
-
-        Args:
-            par (`numpy.ndarray`_, optional):
-                The list of parameters to use. Length should be either
-                :attr:`np` or :attr:`nfree`. If the latter, the values of the
-                fixed parameters in :attr:`par` are used.
-
-        Returns:
-
-            :obj:`tuple`: Model velocity and velocity dispersion data.  The
-            latter is None if the model has no dispersion parameterization.
-        """
-        self._set_par(par)
-        if self.dc is None:
-            vel = self.model()
-            sig = None
-        else:
-            vel, sig = self.model()
-        return self.kin.bin_moments(self.sb, vel, sig)[1:]
-
-#       NOTE: LEAVE THIS OLD CODE HERE, in case we want to test the difference
-#       between the new and old approach.
-#        # TODO: This binning isn't exactly right...  Need to bin velocity and
-#        # velocity dispersion in the same way that we do the beam-smearing.
-#        # I.e., the binned velocity is sum_i w_i v_i / sum_i w_i, where w_i is
-#        # the luminosity weighting.  And the binned velocity dispersion should
-#        # be sqrt(sum_i w_i (v_i^2 + s_i^2) / sum_i w_i - bin_v^2)
-#        return (self.kin.bin(self.model()), None) if self.dc is None \
-#                        else map(lambda x : self.kin.bin(x), self.model())
-
-    def _deriv_binned_model(self, par):
-        """
-        Compute the binned model data and its derivatives.
-
-        Args:
-            par (`numpy.ndarray`_, optional):
-                The list of parameters to use. Length should be either
-                :attr:`np` or :attr:`nfree`. If the latter, the values of the
-                fixed parameters in :attr:`par` are used.
-
-        Returns:
-            :obj:`tuple`: Model velocity data, velocity dispersion data,
-            velocity derivative, and velocity dispersion derivative.  The
-            velocity dispersion components (2nd and 4th objects) are None if the
-            model has no dispersion parameterization.
-        """
-        self._set_par(par)
-        if self.dc is None:
-            vel, dvel = self.deriv_model()
-            sig, dsig = None, None
-        else:
-            vel, sig, dvel, dsig = self.deriv_model()
-        _, vel, sig, _, dvel, dsig \
-                = self.kin.deriv_bin_moments(self.sb, vel, sig, None, dvel, dsig)
-        return vel, sig, dvel, dsig
-
-#       NOTE: LEAVE THIS OLD CODE HERE, in case we want to test the difference
-#       between the new and old approach.
-#        if self.dc is None:
-#            vel, dvel = self.kin.deriv_bin(*self.deriv_model())
-#            return vel, None, dvel, None
-#        vel, sig, dvel, dsig = self.deriv_model()
-#        vel, dvel = self.kin.deriv_bin(vel, dvel)
-#        sig, dsig = self.kin.deriv_bin(sig, dsig)
-#        return vel, sig, dvel, dsig
-
-    def _resid(self, par, sep=False):
-        """
-        Calculate the residuals between the data and the current model.
-
-        Args:
-            par (`numpy.ndarray`_, optional):
-                The list of parameters to use. Length should be either
-                :attr:`np` or :attr:`nfree`. If the latter, the values of the
-                fixed parameters in :attr:`par` are used.
-            sep (:obj:`bool`, optional):
-                Return separate vectors for the velocity and velocity
-                dispersion residuals, instead of appending them.
-
-        Returns:
-            :obj:`tuple`, `numpy.ndarray`_: Difference between the data and the
-            model for all measurements, either returned as a single vector for
-            all data or as separate vectors for the velocity and velocity
-            dispersion data (based on ``sep``).
-        """
-        vel, sig = self._binned_model(par)
-        vfom = self._v_resid(vel)
-        sfom = numpy.array([]) if self.dc is None else self._s_resid(sig)
-        return (vfom, sfom) if sep else np.append(vfom, sfom)
-
-    def _deriv_resid(self, par, sep=False):
-        """
-        Calculate the derivative of the fit residuals w.r.t. all the *free*
-        model parameters.
-
-        Args:
-            par (`numpy.ndarray`_, optional):
-                The list of parameters to use. Length should be either
-                :attr:`np` or :attr:`nfree`. If the latter, the values of the
-                fixed parameters in :attr:`par` are used.
-            sep (:obj:`bool`, optional):
-                Return separate vectors for the velocity and velocity dispersion
-                residual derivatives, instead of appending them.
-
-        Returns:
-            :obj:`tuple`, `numpy.ndarray`_: Derivatives in the difference
-            between the data and the model for all measurements, either returned
-            as a single array for all data or as separate arrays for the
-            velocity and velocity dispersion data (based on ``sep``).
-        """
-        vel, sig, dvel, dsig = self._deriv_binned_model(par)
-        if self.dc is None:
-            return (self._deriv_v_resid(dvel), numpy.array([])) \
-                        if sep else self._deriv_v_resid(dvel)
-        resid = (self._deriv_v_resid(vel), self._deriv_s_resid(sig, dsig))
-        return resid if sep else np.vstack(resid)
-
-    def _chisqr(self, par, sep=False):
-        """
-        Calculate the error-normalized residual (close to the signed
-        chi-square metric) between the data and the current model.
-
-        Args:
-            par (`numpy.ndarray`_, optional):
-                The list of parameters to use. Length should be either
-                :attr:`np` or :attr:`nfree`. If the latter, the values of the
-                fixed parameters in :attr:`par` are used.
-            sep (:obj:`bool`, optional):
-                Return separate vectors for the velocity and velocity
-                dispersion residuals, instead of appending them.
-
-        Returns:
-            :obj:`tuple`, `numpy.ndarray`_: Difference between the data and the
-            model for all measurements, normalized by their errors, either
-            returned as a single vector for all data or as separate vectors for
-            the velocity and velocity dispersion data (based on ``sep``).
-        """
-        vel, sig = self._binned_model(par)
-        if self.has_covar:
-            vfom = self._v_chisqr_covar(vel)
-            sfom = np.array([]) if self.dc is None else self._s_chisqr_covar(sig)
-        else:
-            vfom = self._v_chisqr(vel)
-            sfom = np.array([]) if self.dc is None else self._s_chisqr(sig)
-        return (vfom, sfom) if sep else np.append(vfom, sfom)
-
-    def _deriv_chisqr(self, par, sep=False):
-        """
-        Calculate the derivatives of the error-normalized residuals (close to
-        the signed chi-square metric) w.r.t. the *free* model parameters.
-
-        Args:
-            par (`numpy.ndarray`_, optional):
-                The list of parameters to use. Length should be either
-                :attr:`np` or :attr:`nfree`. If the latter, the values of the
-                fixed parameters in :attr:`par` are used.
-            sep (:obj:`bool`, optional):
-                Return separate vectors for the velocity and velocity
-                dispersion residuals, instead of appending them.
-
-        Returns:
-            :obj:`tuple`, `numpy.ndarray`_: Derivatives of the error-normalized
-            difference between the data and the model for all measurements
-            w.r.t. the *free* model parameters, either returned as a single
-            array for all data or as separate arrays for the velocity and
-            velocity dispersion data (based on ``sep``).
-        """
-        vel, sig, dvel, dsig = self._deriv_binned_model(par)
-        vf = self._deriv_v_chisqr_covar if self.has_covar else self._deriv_v_chisqr
-        if self.dc is None:
-            return (vf(dvel), numpy.array([])) if sep else vf(dvel)
-
-        sf = self._deriv_s_chisqr_covar if self.has_covar else self._deriv_s_chisqr
-        dchisqr = (vf(dvel), sf(sig, dsig))
-        if not np.all(np.isfinite(dchisqr[0])) or not np.all(np.isfinite(dchisqr[1])):
-            raise ValueError('Error in derivative computation.')
-        return dchisqr if sep else np.vstack(dchisqr)
-
-    def _fit_prep(self, kin, p0, fix, scatter, sb_wgt, assume_posdef_covar, ignore_covar, cnvfftw):
-        """
-        Prepare the object for fitting the provided kinematic data.
-
-        Args:
-            kin (:class:`~nirvana.data.kinematics.Kinematics`):
-                The object providing the kinematic data to be fit.
-            p0 (`numpy.ndarray`_):
-                The initial parameters for the model.  Can be None.  Length must
-                be :attr:`np`, if not None.
-            fix (`numpy.ndarray`_):
-                A boolean array selecting the parameters that should be fixed
-                during the model fit.  Can be None.  Length must be :attr:`np`,
-                if not None.
-            scatter (:obj:`float`, array-like):
-                Introduce a fixed intrinsic-scatter term into the model. The 
-                scatter is added in quadrature to all measurement errors in the
-                calculation of the merit function. If no errors are available,
-                this has the effect of renormalizing the unweighted merit
-                function by 1/scatter.  Can be None, which means no intrinsic
-                scatter is added.  If both velocity and velocity dispersion are
-                being fit, this can be a single number applied to both datasets
-                or a 2-element vector that provides different intrinsic scatter
-                measurements for each kinematic moment (ordered velocity then
-                velocity dispersion).
-            sb_wgt (:obj:`bool`):
-                Flag to use the surface-brightness data provided by ``kin``
-                to weight the model when applying the beam-smearing.
-            assume_posdef_covar (:obj:`bool`):
-                If the :class:`~nirvana.data.kinematics.Kinematics` includes
-                covariance matrices, this forces the code to proceed assuming
-                the matrices are positive definite.
-            ignore_covar (:obj:`bool`):
-                If the :class:`~nirvana.data.kinematics.Kinematics` includes
-                covariance matrices, ignore them and just use the inverse
-                variance.
-            cnvfftw (:class:`~nirvana.models.beam.ConvolveFFTW`):
-                An object that expedites the convolutions using FFTW/pyFFTW.  If
-                provided, the shape *must* match ``kin.spatial_shape``.  If
-                None, a new :class:`~nirvana.models.beam.ConvolveFFTW` instance
-                is constructed to perform the convolutions.  If the class cannot
-                be constructed because the user doesn't have pyfftw installed,
-                then the convolutions fall back to the numpy routines.
-        """
-        # Initialize the fit parameters
-        self._init_par(p0, fix)
-        # Initialize the data to fit
-        self.kin = kin
-        self._init_coo(self.kin.grid_x, self.kin.grid_y)
-        self._init_sb(self.kin.grid_sb if sb_wgt else None)
-        self.vel_gpm = np.logical_not(self.kin.vel_mask)
-        self.sig_gpm = None if self.dc is None else np.logical_not(self.kin.sig_mask)
-        # Initialize the beam kernel
-        self._init_beam(self.kin.beam_fft, True, cnvfftw)
-
-        # Determine which errors were provided
-        self.has_err = self.kin.vel_ivar is not None if self.dc is None \
-                        else self.kin.vel_ivar is not None and self.kin.sig_ivar is not None
-        if not self.has_err and (self.kin.vel_err is not None or self.kin.sig_err is not None):
-            warnings.warn('Some errors being ignored if both velocity and velocity dispersion '
-                          'errors are not provided.')
-        self.has_covar = self.kin.vel_covar is not None if self.dc is None \
-                            else self.kin.vel_covar is not None and self.kin.sig_covar is not None
-        if not self.has_covar \
-                and (self.kin.vel_covar is not None or self.kin.sig_covar is not None):
-            warnings.warn('Some covariance matrices being ignored if both velocity and velocity '
-                          'dispersion covariances are not provided.')
-        if ignore_covar:
-            # Force ignoring the covariance
-            # TODO: This requires that, e.g., kin.vel_ivar also be defined...
-            self.has_covar = False
-
-        # Check the intrinsic scatter input
-        self.scatter = None
-        if scatter is not None:
-            self.scatter = np.atleast_1d(scatter)
-            if self.scatter.size > 2:
-                raise ValueError('Should provide, at most, one scatter term for each kinematic '
-                                 'moment being fit.')
-            if self.dc is not None and self.scatter.size == 1:
-                warnings.warn('Using single scatter term for both velocity and velocity '
-                              'dispersion.')
-                self.scatter = np.array([scatter, scatter])
-
-        # Set the internal error attributes
-        if self.has_err:
-            self._v_err = np.sqrt(inverse(self.kin.vel_ivar))
-            self._s_err = None if self.dc is None \
-                                else np.sqrt(inverse(self.kin.sig_phys2_ivar))
-            if self.scatter is not None:
-                self._v_err = np.sqrt(self._v_err**2 + self.scatter[0]**2)
-                if self.dc is not None:
-                    self._s_err = np.sqrt(self._s_err**2 + self.scatter[1]**2)
-        elif not self.has_err and not self.has_covar and self.scatter is not None:
-            self.has_err = True
-            self._v_err = np.full(self.kin.vel.shape, self.scatter[0], dtype=float)
-            self._s_err = None if self.dc is None \
-                                else np.full(self.kin.sig.shape, self.scatter[1], dtype=float)
-        else:
-            self._v_err = None
-            self._s_err = None
-
-        # Set the internal covariance attributes
-        if self.has_covar:
-            # Construct the matrices used to calculate the merit function in
-            # the presence of covariance.
-            vel_pd_covar = self.kin.vel_covar[np.ix_(self.vel_gpm,self.vel_gpm)]
-            sig_pd_covar = None if self.dc is None \
-                            else self.kin.sig_phys2_covar[np.ix_(self.sig_gpm,self.sig_gpm)]
-            if not assume_posdef_covar:
-                # Force the matrices to be positive definite
-                print('Forcing vel covar to be pos-def')
-                vel_pd_covar = impose_positive_definite(vel_pd_covar)
-                print('Forcing sig covar to be pos-def')
-                sig_pd_covar = None if self.dc is None else impose_positive_definite(sig_pd_covar)
-
-            if self.scatter is not None:
-                # A diagonal matrix with only positive values is, by definition,
-                # positive definite; and the sum of two positive-definite
-                # matrices is also positive definite.
-                vel_pd_covar += np.diag(np.full(vel_pd_covar.shape[0], self.scatter[0]**2,
-                                                dtype=float))
-                if self.dc is not None:
-                    sig_pd_covar += np.diag(np.full(sig_pd_covar.shape[0], self.scatter[1]**2,
-                                                    dtype=float))
-
-            self._v_ucov = cinv(vel_pd_covar, upper=True)
-            self._s_ucov = None if sig_pd_covar is None else cinv(sig_pd_covar, upper=True)
-        else:
-            self._v_ucov = None
-            self._s_ucov = None
-
-    def _get_fom(self):
-        """
-        Return the figure-of-merit function to use given the availability of
-        errors.
-        """
-        return self._chisqr if self.has_err or self.has_covar else self._resid
-
-    def _get_jac(self):
-        """
-        Return the Jacobian function to use given the availability of errors.
-        """
-        return self._deriv_chisqr if self.has_err or self.has_covar else self._deriv_resid
-
-    # TODO: Include an argument here that allows the PSF convolution to be
-    # toggled, regardless of whether or not the `kin` object has the beam
-    # defined.
-    def lsq_fit(self, kin, sb_wgt=False, p0=None, fix=None, lb=None, ub=None, scatter=None,
-                verbose=0, assume_posdef_covar=False, ignore_covar=True, cnvfftw=None,
-                analytic_jac=True, maxiter=5):
-        """
-        Use `scipy.optimize.least_squares`_ to fit the model to the provided
-        kinematics.
-
-        It is possible that the call to `scipy.optimize.least_squares`_ returns
-        fitted parameters that are identical to the input guess parameters.
-        Because of this, the fit can be repeated multiple times (see
-        ``maxiter``), where each attempt slightly peturbs the parameters.
-
-        Once complete, the best-fitting parameters are saved to :attr:`par`
-        and the parameter errors (estimated by the parameter covariance
-        matrix constructed as a by-product of the least-squares fit) are
-        saved to :attr:`par_err`.
-
-        .. warning::
-
-            Currently, this class *does not construct a model of the
-            surface-brightness distribution*.  Instead, any weighting of the
-            model during convolution with the beam profile uses the as-observed
-            surface-brightness distribution, instead of a model of the intrinsic
-            surface brightness distribution.  See ``sb_wgt``.
-
-        Args:
-            kin (:class:`~nirvana.data.kinematics.Kinematics`):
-                Object with the kinematic data to fit.
-            sb_wgt (:obj:`bool`, optional):
-                Flag to use the surface-brightness data provided by ``kin`` to
-                weight the model when applying the beam-smearing.  **See the
-                warning above**.
-            p0 (`numpy.ndarray`_, optional):
-                The initial parameters for the model. Length must be
-                :attr:`np`.
-            fix (`numpy.ndarray`_, optional):
-                A boolean array selecting the parameters that should be fixed
-                during the model fit.
-            lb (`numpy.ndarray`_, optional):
-                The lower bounds for the parameters. If None, the defaults
-                are used (see :func:`par_bounds`). The length of the vector
-                must match the total number of parameters, even if some of
-                the parameters are fixed.
-            ub (`numpy.ndarray`_, optional):
-                The upper bounds for the parameters. If None, the defaults
-                are used (see :func:`par_bounds`). The length of the vector
-                must match the total number of parameters, even if some of
-                the parameters are fixed.
-            scatter (:obj:`float`, array-like, optional):
-                Introduce a fixed intrinsic-scatter term into the model. The 
-                scatter is added in quadrature to all measurement errors in the
-                calculation of the merit function. If no errors are available,
-                this has the effect of renormalizing the unweighted merit
-                function by 1/scatter.  Can be None, which means no intrinsic
-                scatter is added.  If both velocity and velocity dispersion are
-                being fit, this can be a single number applied to both datasets
-                or a 2-element vector that provides different intrinsic scatter
-                measurements for each kinematic moment (ordered velocity then
-                velocity dispersion).
-            verbose (:obj:`int`, optional):
-                Verbosity level to pass to `scipy.optimize.least_squares`_.
-            assume_posdef_covar (:obj:`bool`, optional):
-                If the :class:`~nirvana.data.kinematics.Kinematics` includes
-                covariance matrices, this forces the code to proceed assuming
-                the matrices are positive definite.
-            ignore_covar (:obj:`bool`, optional):
-                If the :class:`~nirvana.data.kinematics.Kinematics` includes
-                covariance matrices, ignore them and just use the inverse
-                variance.
-            cnvfftw (:class:`~nirvana.models.beam.ConvolveFFTW`, optional):
-                An object that expedites the convolutions using FFTW/pyFFTW.  If
-                provided, the shape *must* match ``kin.spatial_shape``.  If
-                None, a new :class:`~nirvana.models.beam.ConvolveFFTW` instance
-                is constructed to perform the convolutions.  If the class cannot
-                be constructed because the user doesn't have pyfftw installed,
-                then the convolutions fall back to the numpy routines.
-            analytic_jac (:obj:`bool`, optional):
-                Use the analytic calculation of the Jacobian matrix during the
-                fit optimization.  If False, the Jacobian is calculated using
-                finite-differencing methods provided by
-                `scipy.optimize.least_squares`_.
-            maxiter (:obj:`int`, optional):
-                The call to `scipy.optimize.least_squares`_ is repeated when it
-                returns best-fit parameters that are *identical* to the input
-                parameters.  This parameter sets the maximum number of times the
-                fit will be repeated.  Set this to 1 to ignore these occurences;
-                ``maxiter`` cannot be None.
-        """
-        if maxiter is None:
-            raise ValueError('Maximum number of iterations cannot be None.')
-
-        # Prepare to fit the data.
-        self._fit_prep(kin, p0, fix, scatter, sb_wgt, assume_posdef_covar, ignore_covar,
-                       cnvfftw)
-        
-        # Get the method used to generate the figure-of-merit and the Jacobian
-        # matrix.
-        fom = self._get_fom()
-        # If the analytic Jacobian matrix is not used, the derivative of the
-        # merit function wrt each parameter is determined by a 1% change in each
-        # parameter.
-        jac_kwargs = {'jac': self._get_jac()} if analytic_jac \
-                        else {'diff_step': np.full(self.np, 0.01, dtype=float)[self.free]}
-
-        # Parameter boundaries
-        _lb, _ub = self.par_bounds()
-        if lb is None:
-            lb = _lb
-        if ub is None:
-            ub = _ub
-        if len(lb) != self.np or len(ub) != self.np:
-            raise ValueError('Length of one or both of the bound vectors is incorrect.')
-
-        # Set the random number generator with a fixed seed so that the result
-        # is deterministic.
-        rng = np.random.default_rng(seed=909)
-        _p0 = self.par[self.free]
-        p = _p0.copy()
-        pe = None
-        niter = 0
-        while niter < maxiter:
-            # Run the optimization
-            result = optimize.least_squares(fom, p, # method='lm', #xtol=None,
-                                            x_scale='jac', method='trf', xtol=1e-12,
-                                            bounds=(lb[self.free], ub[self.free]), 
-                                            verbose=max(verbose,0), **jac_kwargs)
-            try:
-                pe = np.sqrt(np.diag(cov_err(result.jac)))
-            except:
-                warnings.warn('Unable to compute parameter errors from precision matrix.')
-                pe = None
-
-            # The fit should change the input parameters.
-            if np.all(np.absolute(p-result.x) > 1e-3):
-                break
-
-            # If it doesn't, something likely went wrong with the fit.  Perturb
-            # the input guesses a bit and retry.
-            p = _p0 + rng.normal(size=self.nfree)*(pe if pe is not None else 0.1*p0)
-            p = np.clip(p, lb[self.free], ub[self.free])
-            niter += 1
-
-        # TODO: Add something to the fit status/success flags that tests if
-        # niter == maxiter and/or if the input parameters are identical to the
-        # final best-fit prameters?  Note that the input parameters, p0, may not
-        # be identical to the output parameters because of the iterations mean
-        # that p != p0 !
-
-        # Save the fit status
-        self.fit_status = result.status
-        self.fit_success = result.success
-
-        # Save the best-fitting parameters
-        self._set_par(result.x)
-        if pe is None:
-            self.par_err = None
-        else:
-            self.par_err = np.zeros(self.np, dtype=float)
-            self.par_err[self.free] = pe
-
-        # Print the report
-        if verbose > -1:
-            self.report(fit_message=result.message)
 
     def report(self, fit_message=None):
         """

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -23,7 +23,6 @@ from ..data.kinematics import Kinematics
 from ..data.scatter import IntrinsicScatter
 from ..data.util import inverse, find_largest_coherent_region
 from ..data.util import select_major_axis, bin_stats, growth_lim, atleast_one_decade
-from ..util.bitmask import BitMask
 from ..util import plot
 from ..util import fileio
 
@@ -83,8 +82,8 @@ def disk_fit_reject(kin, disk, disp=None, ignore_covar=True, vel_mask=None, vel_
             Write the QA plot for the velocity dispersion rejection to this
             file (see :func:`~nirvana.data.scatter.IntrinsicScatter.show`).
         rej_flag (:obj:`str`, optional):
-            Rejection flag giving the reason these data were rejected. Must
-            be a valid flag for :class:`AxisymmetricDiskFitBitMask`.
+            Rejection flag giving the reason these data were rejected. Must be a
+            valid flag for :class:`~nirvana.models.thindisk.ThinDiskFitBitMask`.
         verbose (:obj:`bool`, optional):
             Verbose scatter fitting output.
 
@@ -274,41 +273,41 @@ def reset_to_base_flags(disk, kin, vel_mask, sig_mask):
         kin.sig_mask = disk.mbm.flagged(sig_mask, flag=disk.mbm.base_flags())
 
 
-class AxisymmetricDiskFitBitMask(BitMask):
-    """
-    Bin-by-bin mask used to track axisymmetric disk fit rejections.
-    """
-    def __init__(self):
-        # TODO: np.array just used for slicing convenience
-        mask_def = np.array([['DIDNOTUSE', 'Data not used because it was flagged on input.'],
-                             ['REJ_ERR', 'Data rejected because of its large measurement error.'],
-                             ['REJ_SNR', 'Data rejected because of its low signal-to-noise.'],
-                             ['REJ_UNR', 'Data rejected after first iteration and are so '
-                                         'discrepant from the other data that we expect the '
-                                         'measurements are unreliable.'],
-                             ['REJ_RESID', 'Data rejected due to iterative rejection process '
-                                           'of model residuals.'],
-                             ['DISJOINT', 'Data part of a smaller disjointed region, not '
-                                          'congruent with the main body of the measurements.']])
-        super().__init__(mask_def[:,0], descr=mask_def[:,1])
-
-    @staticmethod
-    def base_flags():
-        """
-        Return the list of "base-level" flags that are *always* ignored,
-        regardless of the fit iteration.
-        """
-        return ['DIDNOTUSE', 'REJ_ERR', 'REJ_SNR', 'REJ_UNR', 'DISJOINT']
-
-
-class AxisymmetricDiskGlobalBitMask(BitMask):
-    """
-    Fit-wide quality flag.
-    """
-    def __init__(self):
-        # NOTE: np.array just used for slicing convenience
-        mask_def = np.array([['LOWINC', 'Fit has an erroneously low inclination']])
-        super().__init__(mask_def[:,0], descr=mask_def[:,1])
+#class AxisymmetricDiskFitBitMask(BitMask):
+#    """
+#    Bin-by-bin mask used to track axisymmetric disk fit rejections.
+#    """
+#    def __init__(self):
+#        # TODO: np.array just used for slicing convenience
+#        mask_def = np.array([['DIDNOTUSE', 'Data not used because it was flagged on input.'],
+#                             ['REJ_ERR', 'Data rejected because of its large measurement error.'],
+#                             ['REJ_SNR', 'Data rejected because of its low signal-to-noise.'],
+#                             ['REJ_UNR', 'Data rejected after first iteration and are so '
+#                                         'discrepant from the other data that we expect the '
+#                                         'measurements are unreliable.'],
+#                             ['REJ_RESID', 'Data rejected due to iterative rejection process '
+#                                           'of model residuals.'],
+#                             ['DISJOINT', 'Data part of a smaller disjointed region, not '
+#                                          'congruent with the main body of the measurements.']])
+#        super().__init__(mask_def[:,0], descr=mask_def[:,1])
+#
+#    @staticmethod
+#    def base_flags():
+#        """
+#        Return the list of "base-level" flags that are *always* ignored,
+#        regardless of the fit iteration.
+#        """
+#        return ['DIDNOTUSE', 'REJ_ERR', 'REJ_SNR', 'REJ_UNR', 'DISJOINT']
+#
+#
+#class AxisymmetricDiskGlobalBitMask(BitMask):
+#    """
+#    Fit-wide quality flag.
+#    """
+#    def __init__(self):
+#        # NOTE: np.array just used for slicing convenience
+#        mask_def = np.array([['LOWINC', 'Fit has an erroneously low inclination']])
+#        super().__init__(mask_def[:,0], descr=mask_def[:,1])
 
 
 class AxisymmetricDisk(ThinDisk):
@@ -355,15 +354,15 @@ class AxisymmetricDisk(ThinDisk):
 
     """
 
-    gbm = AxisymmetricDiskGlobalBitMask()
-    """
-    Global bitmask.
-    """
-
-    mbm = AxisymmetricDiskFitBitMask()
-    """
-    Measurement-specific bitmask.
-    """
+#    gbm = AxisymmetricDiskGlobalBitMask()
+#    """
+#    Global bitmask.
+#    """
+#
+#    mbm = AxisymmetricDiskFitBitMask()
+#    """
+#    Measurement-specific bitmask.
+#    """
 
     def __init__(self, rc=None, dc=None):
         # Rotation curve
@@ -2242,6 +2241,11 @@ def axisym_iter_fit(galmeta, kin, rctype='HyperbolicTangent', dctype='Exponentia
                               vel_mask=vel_mask, vel_sigma_rej=_vel_sigma_rej[0], show_vel=debug,
                               sig_mask=sig_mask, sig_sigma_rej=_sig_sigma_rej[0], show_sig=debug,
                               rej_flag='REJ_UNR', verbose=verbose > 1)
+
+#        # Incorporate into mask
+#        if vel_mask is not None and np.any(vel_rej):
+#            vel_mask[vel_rej] = disk.mbm.turn_on(vel_mask[vel_rej], rej_flag)
+
     #   - Incorporate the rejection into the Kinematics object
     print(f'Rejecting {0 if vel_rej is None else np.sum(vel_rej)} velocity measurements.')
     if disk.dc is not None:

--- a/nirvana/models/bisym.py
+++ b/nirvana/models/bisym.py
@@ -38,6 +38,8 @@ from .util import cov_err
 from ..data.scatter import IntrinsicScatter
 from ..data.util import impose_positive_definite, inverse
 
+from .thindisk import ThinDisk
+
 #warnings.simplefilter('ignore', RuntimeWarning)
 
 def smoothing(array, weight=1):
@@ -536,7 +538,7 @@ def fit(plate, ifu, galmeta = None, daptype='HYB10-MILESHC-MASTARHC2', dr='MPL-1
     return sampler, args
 
 
-class BisymmetricDisk:
+class BisymmetricDisk(ThinDisk):
     r"""
     Model for a rotating thin disk with a bisymmetric flow; cf. Spekkens &
     Sellwood (2007, ApJ, 664, 204).
@@ -598,50 +600,25 @@ class BisymmetricDisk:
         # Velocity dispersion curve (can be None)
         self.dc = dc
 
-        # Number of "base" parameters
-        self.nbp = 6
-        # Total number of parameters
-        self.np = self.nbp + self.vt.np + self.v2t.np + self.v2r.np
+        # Instantiate the base class, which basically keeps all of the geometric
+        # parameters.  NOTE: The parametric curves above need to be defined
+        # first because instatiation of the base class calls reinit(), which
+        # sets default guess parameters.  TODO: Consider instantiating without
+        # guess parameters...
+        super().__init__()
+
+        # Total number of parameters:  Basic geometric parameters, the position
+        # angle of the bisymmetry, and the radials profiles of the velocity
+        # terms.
+        self.np = self.nbp + 1 + self.vt.np + self.v2t.np + self.v2r.np
         if self.dc is not None:
+            # Add in the velocity dispersion terms.
             self.np += self.dc.np
-        # Initialize the parameters (see reinit function)
-        self.par_err = None
         # Flag which parameters are freely fit
         self.free = np.ones(self.np, dtype=bool)
         self.nfree = np.sum(self.free)
         # This call to reinit adds the workspace attributes
         self.reinit()
-
-    def __repr__(self):
-        """
-        Provide the representation of the object when written to the screen.
-        """
-        # Collect the attributes relevant to construction of a model
-        attr = [n for n in ['par', 'x', 'y', 'sb', 'beam_fft'] if getattr(self, n) is not None]
-        return f'<{self.__class__.__name__}: Defined attr - {",".join(attr)}>'
-
-    def reinit(self):
-        """
-        Reinitialize the object.
-
-        This resets the model parameters to the guess parameters and erases any
-        existing data used to construct the models.  Note that, just like when
-        instantiating a new object, any calls to :func:`model` after
-        reinitialization will require at least the coordinates (``x`` and ``y``)
-        to be provided to successfully calculate the model.
-        """
-        self.par = self.guess_par()
-        self.x = None
-        self.y = None
-        self.beam_fft = None
-        self.kin = None
-        self.sb = None
-        self.vel_gpm = None
-        self.sig_gpm = None
-        self.cnvfftw = None
-        self.global_mask = 0
-        self.fit_status = None
-        self.fit_success = None
 
     def guess_par(self):
         """
@@ -654,8 +631,7 @@ class BisymmetricDisk:
         Returns:
             `numpy.ndarray`_: Vector of guess parameters
         """
-        # Return the 
-        gp = np.concatenate(([0., 0., 45., 30., 0., 0.], self.vt.guess_par(),
+        gp = np.concatenate((super().guess_par(), [0.], self.vt.guess_par(),
                              self.v2t.guess_par(), self.v2r.guess_par()))
         return gp if self.dc is None else np.append(gp, self.dc.guess_par())
 
@@ -670,15 +646,15 @@ class BisymmetricDisk:
         Returns:
             :obj:`list`: List of parameter name strings.
         """
+        base = super().par_names(short=short)
         if short:
-            base = ['x0', 'y0', 'pa', 'inc', 'vsys', 'pab']
+            base += ['pab']
             vt = [f'vt_{p}' for p in self.vt.par_names(short=True)]
             v2t = [f'v2t_{p}' for p in self.v2t.par_names(short=True)]
             v2r = [f'v2r_{p}' for p in self.v2r.par_names(short=True)]
             dc = [] if self.dc is None else [f's_{p}' for p in self.dc.par_names(short=True)]
         else:
-            base = ['X center', 'Y center', 'Position Angle', 'Inclination', 'Systemic Velocity',
-                    'Bisymmetry PA']
+            base += ['Bisymmetry PA']
             vt = [f'VT: {p}' for p in self.vt.par_names()]
             v2t = [f'V2T: {p}' for p in self.v2t.par_names()]
             v2r = [f'V2R: {p}' for p in self.v2r.par_names()]
@@ -687,36 +663,18 @@ class BisymmetricDisk:
 
     # These "private" functions yield slices of the parameter vector for the
     # desired set of parameters
-    def _base_slice(self):
-        return slice(self.nbp)
     def _vt_slice(self):
-        s = self.nbp
+        s = self.nbp + 1
         return slice(s, s + self.vt.np)
     def _v2t_slice(self):
-        s = self.nbp + self.vt.np
+        s = self.nbp + 1 + self.vt.np
         return slice(s, s + self.v2t.np)
     def _v2r_slice(self):
-        s = self.nbp + self.vt.np + self.v2t.np
+        s = self.nbp + 1 + self.vt.np + self.v2t.np
         return slice(s, s + self.v2r.np)
     def _dc_slice(self):
-        s = self.nbp + self.vt.np + self.v2t.np + self.v2r.np
+        s = self.nbp + 1 + self.vt.np + self.v2t.np + self.v2r.np
         return slice(s, s + self.dc.np)
-
-    def base_par(self, err=False):
-        """
-        Return the base (largely geometric) parameters. Returns None if
-        parameters are not defined yet.
-
-        Args:
-            err (:obj:`bool`, optional):
-                Return the parameter errors instead of the parameter values.
-
-        Returns:
-            `numpy.ndarray`_: Vector with parameters or parameter errors for the
-            "base" parameters.
-        """
-        p = self.par_err if err else self.par
-        return None if p is None else p[self._base_slice()]
 
     def vt_par(self, err=False):
         """
@@ -782,7 +740,7 @@ class BisymmetricDisk:
         p = self.par_err if err else self.par
         return None if p is None or self.dc is None else p[self._dc_slice()]
 
-    def par_bounds(self, base_lb=None, base_ub=None):
+    def par_bounds(self, base_lb=None, base_ub=None, pab_lb=None, pab_ub=None):
         """
         Return the lower and upper boundaries on the model parameters.
 
@@ -808,201 +766,13 @@ class BisymmetricDisk:
             :obj:`tuple`: A two-tuple providing, respectively, the lower and
             upper boundaries for all model parameters.
         """
-        if base_lb is not None and len(base_lb) != self.nbp:
-            raise ValueError('Incorrect number of lower bounds for the base '
-                             f'parameters; found {len(base_lb)}, expected {self.nbp}.')
-        if base_ub is not None and len(base_ub) != self.nbp:
-            raise ValueError('Incorrect number of upper bounds for the base '
-                             f'parameters; found {len(base_ub)}, expected {self.nbp}.')
-
-        if (base_lb is None or base_ub is None) and (self.x is None or self.y is None):
-            raise ValueError('Cannot define limits on center.  Provide base_lb,base_ub or set '
-                             'the evaluation grid coordinates (attributes x and y).')
-
-        if base_lb is None:
-            minx = np.amin(self.x)
-            miny = np.amin(self.y)
-            base_lb = np.array([minx, miny, -350., 1., -300., -100.])
-        if base_ub is None:
-            maxx = np.amax(self.x)
-            maxy = np.amax(self.y)
-            base_ub = np.array([maxx, maxy, 350., 89., 300., 100.])
-        # Minimum and maximum allowed values
-        lb = np.concatenate((base_lb, self.vt.lb, self.v2t.lb, self.v2r.lb))
-        ub = np.concatenate((base_ub, self.vt.ub, self.v2t.ub, self.v2r.ub))
+        _base_lb, _base_ub = super().par_bounds(base_lb=base_lb, base_ub=base_ub)
+        _base_lb = np.append(_base_lb, [-100. if pab_lb is None else pab_lb])
+        _base_ub = np.append(_base_ub, [100. if pab_ub is None else pab_ub])
+        lb = np.concatenate((_base_lb, self.vt.lb, self.v2t.lb, self.v2r.lb))
+        ub = np.concatenate((_base_ub, self.vt.ub, self.v2t.ub, self.v2r.ub))
         return (lb, ub) if self.dc is None \
                     else (np.append(lb, self.dc.lb), np.append(ub, self.dc.ub))
-
-    def _set_par(self, par):
-        """
-        Set the full parameter vector, accounting for any fixed parameters.
-
-        Args:
-            par (`numpy.ndarray`_, optional):
-                The list of parameters to use. Length should be either
-                :attr:`np` or :attr:`nfree`. If the latter, the values of the
-                fixed parameters in :attr:`par` are used.
-        """
-        if par.ndim != 1:
-            raise ValueError('Parameter array must be a 1D vector.')
-        if par.size == self.np:
-            self.par = par.copy()
-            return
-        if par.size != self.nfree:
-            raise ValueError('Must provide {0} or {1} parameters.'.format(self.np, self.nfree))
-        self.par[self.free] = par.copy()
-
-    def _init_coo(self, x, y):
-        """
-        Initialize the coordinate arrays.
-
-        .. warning::
-            
-            Input coordinate data types are all converted to `numpy.float64`_.
-            This is always true, even though this is only needed when using
-            :class:`~nirvana.models.beam.ConvolveFFTW`.
-
-        Args:
-            x (`numpy.ndarray`_):
-                The 2D x-coordinates at which to evaluate the model.  If not
-                None, replace the existing :attr:`x` with this array.
-            y (`numpy.ndarray`_):
-                The 2D y-coordinates at which to evaluate the model.  If not
-                None, replace the existing :attr:`y` with this array.
-
-        Raises:
-            ValueError:
-                Raised if the shapes of :attr:`x` and :attr:`y` are not the same.
-        """
-        if x is None and y is None:
-            # Nothing to do
-            return
-
-        # Define it and check it
-        if x is not None:
-            self.x = x.astype(float)
-        if y is not None:
-            self.y = y.astype(float)
-        if self.x.shape != self.y.shape:
-            raise ValueError('Input coordinates must have the same shape.')
-
-    def _init_sb(self, sb):
-        """
-        Initialize the surface brightness array.
-
-        .. warning::
-            
-            Input surface-brightness data types are all converted to
-            `numpy.float64`_.  This is always true, even though this is only
-            needed when using :class:`~nirvana.models.beam.ConvolveFFTW`.
-
-        Args:
-            sb (`numpy.ndarray`_):
-                2D array with the surface brightness of the object.  If not
-                None, replace the existing :attr:`sb` with this array.
-
-        Raises:
-            ValueError:
-                Raised if the shapes of :attr:`sb` and :attr:`x` are not the same.
-        """
-        if sb is None:
-            # Nothing to do
-            return
-
-        # Check it makes sense to define the surface brightness
-        if self.x is None:
-            raise ValueError('Input coordinates must be instantiated first!')
-
-        # Define it and check it
-        self.sb = sb.astype(float)
-        if self.sb.shape != self.x.shape:
-            raise ValueError('Input coordinates must have the same shape.')
-
-    def _init_beam(self, beam, is_fft, cnvfftw):
-        """
-        Initialize the beam-smearing kernel and the convolution method.
-
-        Args:
-            beam (`numpy.ndarray`_):
-                The 2D rendering of the beam-smearing kernel, or its Fast
-                Fourier Transform (FFT).  If not None, replace existing
-                :attr:`beam_fft` with this array (or its FFT, depending on the
-                provided ``is_fft``).
-            is_fft (:obj:`bool`):
-                The provided ``beam`` object is already the FFT of the
-                beam-smearing kernel.
-            cnvfftw (:class:`~nirvana.models.beam.ConvolveFFTW`):
-                An object that expedites the convolutions using FFTW/pyFFTW.  If
-                provided, the shape *must* match :attr:``beam_fft`` (after this
-                is potentially updated by the provided ``beam``).  If None, a
-                new :class:`~nirvana.models.beam.ConvolveFFTW` instance is
-                constructed to perform the convolutions.  If the class cannot be
-                constructed because the user doesn't have pyfftw installed, then
-                the convolutions fall back to the numpy routines.
-        """
-        if beam is None:
-            # Nothing to do
-            return
-
-        # Check it makes sense to define the beam
-        if self.x is None:
-            raise ValueError('Input coordinates must be instantiated first!')
-        if self.x.ndim != 2:
-            raise ValueError('To perform convolution, must provide 2d coordinate arrays.')
-
-        # Assign the beam and check it
-        self.beam_fft = beam if is_fft else np.fft.fftn(np.fft.ifftshift(beam))
-        if self.beam_fft.shape != self.x.shape:
-            raise ValueError('Currently, convolution requires the beam map to have the same '
-                                'shape as the coordinate maps.')
-
-        # Convolutions will be performed, try to setup the ConvolveFFTW
-        # object (self.cnvfftw).
-        if cnvfftw is None:
-            if self.cnvfftw is not None and self.cnvfftw.shape == self.beam_fft.shape:
-                # ConvolveFFTW is ready to go
-                return
-
-            try:
-                self.cnvfftw = ConvolveFFTW(self.beam_fft.shape)
-            except:
-                warnings.warn('Could not instantiate ConvolveFFTW; proceeding with numpy '
-                              'FFT/convolution routines.')
-                self.cnvfftw = None
-        else:
-            # A cnvfftw was provided, check it
-            if not isinstance(cnvfftw, ConvolveFFTW):
-                raise TypeError('Provided cnvfftw must be a ConvolveFFTW instance.')
-            if cnvfftw.shape != self.beam_fft.shape:
-                raise ValueError('cnvfftw shape does not match beam shape.')
-            self.cnvfftw = cnvfftw
-
-    def _init_par(self, p0, fix):
-        """
-        Initialize the relevant parameter vectors that tracks the full set of
-        model parameters and which of those are freely fit by the model.
-
-        Args:
-            p0 (`numpy.ndarray`_):
-                The initial parameters for the model.  Can be None.  Length must
-                be :attr:`np`, if not None.
-            fix (`numpy.ndarray`_):
-                A boolean array selecting the parameters that should be fixed
-                during the model fit.  Can be None.  Length must be :attr:`np`,
-                if not None.
-        """
-        if p0 is None:
-            p0 = self.guess_par()
-        _p0 = np.atleast_1d(p0)
-        if _p0.size != self.np:
-            raise ValueError('Incorrect number of model parameters.')
-        self.par = _p0.copy()
-        self.par_err = None
-        _free = np.ones(self.np, dtype=bool) if fix is None else np.logical_not(fix)
-        if _free.size != self.np:
-            raise ValueError('Incorrect number of model parameter fitting flags.')
-        self.free = _free.copy()
-        self.nfree = np.sum(self.free)
 
     def in_disk_bar_angle(self, par=None):
         # Reset the parameter values
@@ -1074,21 +844,8 @@ class BisymmetricDisk:
             `numpy.ndarray`_, :obj:`tuple`: The velocity field model, and the
             velocity dispersion field model, if the latter is included
         """
-        # Initialize the coordinates (this does nothing if both x and y are None)
-        self._init_coo(x, y)
-        # Initialize the surface brightness (this does nothing if sb is None)
-        self._init_sb(sb)
-        # Initialize the convolution kernel (this does nothing if beam is None)
-        self._init_beam(beam, is_fft, cnvfftw)
-        if self.beam_fft is not None and not ignore_beam:
-            # Initialize the surface brightness, only if it would be used
-            self._init_sb(sb)
-        # Check that the model can be calculated
-        if self.x is None or self.y is None:
-            raise ValueError('No coordinate grid defined.')
-        # Reset the parameter values
-        if par is not None:
-            self._set_par(par)
+        # Initialize the thin disk model
+        self._init_model(par, x, y, sb, beam, is_fft, cnvfftw, ignore_beam)
 
         # Get the coordinate data
         #   - Convert the relevant angles to radians
@@ -1124,22 +881,65 @@ class BisymmetricDisk:
     def deriv_model(self, par=None, x=None, y=None, sb=None, beam=None, is_fft=False, cnvfftw=None,
                     ignore_beam=False):
         """
+        Evaluate the derivative of the model w.r.t all input parameters.
+
+        Note that arguments passed to this function overwrite any existing
+        attributes of the object, and subsequent calls to this function will
+        continue to use existing attributes, unless they are overwritten.  For
+        example, if ``beam`` is provided here, it overwrites any existing
+        :attr:`beam_fft` and any subsequent calls to ``model`` **that do not
+        provide a new** ``beam`` will use the existing :attr:`beam_fft`.  To
+        remove all internal attributes to get a "clean" instantiation, either
+        define a new :class:`AxisymmetricDisk` instance or use :func:`reinit`.
+
+        .. warning::
+            
+            Input coordinates and surface-brightness data types are all
+            converted to `numpy.float64`_.  This is always true, even though
+            this is only needed when using
+            :class:`~nirvana.models.beam.ConvolveFFTW`.
+
+        Args:
+            par (`numpy.ndarray`_, optional):
+                The list of parameters to use. If None, the internal
+                :attr:`par` is used. Length should be either :attr:`np` or
+                :attr:`nfree`. If the latter, the values of the fixed
+                parameters in :attr:`par` are used.
+            x (`numpy.ndarray`_, optional):
+                The 2D x-coordinates at which to evaluate the model. If not
+                provided, the internal :attr:`x` is used.
+            y (`numpy.ndarray`_, optional):
+                The 2D y-coordinates at which to evaluate the model. If not
+                provided, the internal :attr:`y` is used.
+            sb (`numpy.ndarray`_, optional):
+                2D array with the surface brightness of the object. This is used
+                to weight the convolution of the kinematic fields according to
+                the luminosity distribution of the object.  Must have the same
+                shape as ``x``. If None, the convolution is unweighted.  If a
+                convolution is not performed (either ``beam`` or
+                :attr:`beam_fft` are not available, or ``ignore_beam`` is True),
+                this array is ignored.
+            beam (`numpy.ndarray`_, optional):
+                The 2D rendering of the beam-smearing kernel, or its Fast
+                Fourier Transform (FFT). If not provided, the internal
+                :attr:`beam_fft` is used.
+            is_fft (:obj:`bool`, optional):
+                The provided ``beam`` object is already the FFT of the
+                beam-smearing kernel.  Ignored if ``beam`` is not provided.
+            cnvfftw (:class:`~nirvana.models.beam.ConvolveFFTW`, optional):
+                An object that expedites the convolutions using
+                FFTW/pyFFTW. If None, the convolution is done using numpy
+                FFT routines.
+            ignore_beam (:obj:`bool`, optional):
+                Ignore the beam-smearing when constructing the model. I.e.,
+                construct the *intrinsic* model.
+
+        Returns:
+            `numpy.ndarray`_, :obj:`tuple`: The velocity field model, and the
+            velocity dispersion field model, if the latter is included
         """
-        # Initialize the coordinates (this does nothing if both x and y are None)
-        self._init_coo(x, y)
-        # Initialize the surface brightness (this does nothing if sb is None)
-        self._init_sb(sb)
-        # Initialize the convolution kernel (this does nothing if beam is None)
-        self._init_beam(beam, is_fft, cnvfftw)
-        if self.beam_fft is not None and not ignore_beam:
-            # Initialize the surface brightness, only if it would be used
-            self._init_sb(sb)
-        # Check that the model can be calculated
-        if self.x is None or self.y is None:
-            raise ValueError('No coordinate grid defined.')
-        # Reset the parameter values
-        if par is not None:
-            self._set_par(par)
+        # Initialize the thin disk model
+        self._init_model(par, x, y, sb, beam, is_fft, cnvfftw, ignore_beam)
 
         # Initialize the derivative arrays needed for the coordinate calculation
         dx = np.zeros(self.x.shape+(self.np,), dtype=float)
@@ -1233,425 +1033,6 @@ class BisymmetricDisk:
                                              sig=sig, dsig=dsig, cnvfftw=self.cnvfftw)
         return v, sig, dv, dsig
 
-
-
-#    def mock_observation(self, par, kin=None, x=None, y=None, sb=None, binid=None,
-#                         vel_ivar=None, vel_covar=None, vel_mask=None, sig_ivar=None,
-#                         sig_covar=None, sig_mask=None, sig_corr=None, beam=None, is_fft=False,
-#                         cnvfftw=None, ignore_beam=False, add_err=False, positive_definite=False,
-#                         rng=None):
-
-    def fisher_matrix(self, par, kin, fix=None, sb_wgt=False, scatter=None,
-                      assume_posdef_covar=False, ignore_covar=True, cnvfftw=None,
-                      inverse=False):
-        """
-        """
-        self._fit_prep(kin, par, fix, scatter, sb_wgt, assume_posdef_covar, ignore_covar,
-                       cnvfftw)
-        jac = self._get_jac()(self.par[self.free])
-        return cov_err(jac) if inverse else np.dot(jac.T,jac)
-
-    # This slew of "private" functions consolidate the velocity residual and
-    # chi-square calculations
-    def _v_resid(self, vel):
-        return self.kin.vel[self.vel_gpm] - vel[self.vel_gpm]
-    def _deriv_v_resid(self, dvel):
-        return -dvel[np.ix_(self.vel_gpm, self.free)]
-    def _v_chisqr(self, vel):
-        return self._v_resid(vel) / self._v_err[self.vel_gpm]
-    def _deriv_v_chisqr(self, dvel):
-        return self._deriv_v_resid(dvel) / self._v_err[self.vel_gpm, None]
-    def _v_chisqr_covar(self, vel):
-        return np.dot(self._v_resid(vel), self._v_ucov)
-    def _deriv_v_chisqr_covar(self, dvel):
-        return np.dot(self._deriv_v_resid(dvel).T, self._v_ucov).T
-
-    # This slew of "private" functions consolidate the velocity dispersion
-    # residual and chi-square calculations
-    def _s_resid(self, sig):
-        return self.kin.sig_phys2[self.sig_gpm] - sig[self.sig_gpm]**2
-    def _deriv_s_resid(self, sig, dsig):
-        return -2 * sig[self.sig_gpm,None] * dsig[np.ix_(self.sig_gpm, self.free)]
-    def _s_chisqr(self, sig):
-        return self._s_resid(sig) / self._s_err[self.sig_gpm]
-    def _deriv_s_chisqr(self, sig, dsig):
-        return self._deriv_s_resid(sig, dsig) / self._s_err[self.sig_gpm, None]
-    def _s_chisqr_covar(self, sig):
-        return np.dot(self._s_resid(sig), self._s_ucov)
-    def _deriv_s_chisqr_covar(self, sig, dsig):
-        return np.dot(self._deriv_s_resid(sig, dsig).T, self._s_ucov).T
-
-    def _binned_model(self, par):
-        """
-        Compute the binned model data.
-
-        Args:
-            par (`numpy.ndarray`_, optional):
-                The list of parameters to use. Length should be either
-                :attr:`np` or :attr:`nfree`. If the latter, the values of the
-                fixed parameters in :attr:`par` are used.
-
-        Returns:
-
-            :obj:`tuple`: Model velocity and velocity dispersion data.  The
-            latter is None if the model has no dispersion parameterization.
-        """
-        self._set_par(par)
-        if self.dc is None:
-            vel = self.model()
-            sig = None
-        else:
-            vel, sig = self.model()
-        return self.kin.bin_moments(self.sb, vel, sig)[1:]
-
-    def _deriv_binned_model(self, par):
-        """
-        Compute the binned model data and its derivatives.
-
-        Args:
-            par (`numpy.ndarray`_, optional):
-                The list of parameters to use. Length should be either
-                :attr:`np` or :attr:`nfree`. If the latter, the values of the
-                fixed parameters in :attr:`par` are used.
-
-        Returns:
-            :obj:`tuple`: Model velocity data, velocity dispersion data,
-            velocity derivative, and velocity dispersion derivative.  The
-            velocity dispersion components (2nd and 4th objects) are None if the
-            model has no dispersion parameterization.
-        """
-        self._set_par(par)
-        if self.dc is None:
-            vel, dvel = self.deriv_model()
-            sig, dsig = None, None
-        else:
-            vel, sig, dvel, dsig = self.deriv_model()
-        _, vel, sig, _, dvel, dsig \
-                = self.kin.deriv_bin_moments(self.sb, vel, sig, None, dvel, dsig)
-        return vel, sig, dvel, dsig
-
-    def _resid(self, par, sep=False):
-        """
-        Calculate the residuals between the data and the current model.
-
-        Args:
-            par (`numpy.ndarray`_, optional):
-                The list of parameters to use. Length should be either
-                :attr:`np` or :attr:`nfree`. If the latter, the values of the
-                fixed parameters in :attr:`par` are used.
-            sep (:obj:`bool`, optional):
-                Return separate vectors for the velocity and velocity
-                dispersion residuals, instead of appending them.
-
-        Returns:
-            `numpy.ndarray`_: Difference between the data and the model for
-            all measurements.
-        """
-        vel, sig = self._binned_model(par)
-        vfom = self._v_resid(vel)
-        sfom = numpy.array([]) if self.dc is None else self._s_resid(sig)
-        return (vfom, sfom) if sep else np.append(vfom, sfom)
-
-    def _deriv_resid(self, par, sep=False):
-        """
-        Calculate the derivative of the fit residuals w.r.t. all the *free*
-        model parameters.
-
-        Args:
-            par (`numpy.ndarray`_, optional):
-                The list of parameters to use. Length should be either
-                :attr:`np` or :attr:`nfree`. If the latter, the values of the
-                fixed parameters in :attr:`par` are used.
-            sep (:obj:`bool`, optional):
-                Return separate vectors for the velocity and velocity dispersion
-                residual derivatives, instead of appending them.
-
-        Returns:
-            :obj:`tuple`, `numpy.ndarray`_: Derivatives in the difference
-            between the data and the model for all measurements, either returned
-            as a single array for all data or as separate arrays for the
-            velocity and velocity dispersion data (based on ``sep``).
-        """
-        vel, sig, dvel, dsig = self._deriv_binned_model(par)
-        if self.dc is None:
-            return (self._deriv_v_resid(dvel), numpy.array([])) \
-                        if sep else self._deriv_v_resid(dvel)
-        resid = (self._deriv_v_resid(vel), self._deriv_s_resid(sig, dsig))
-        return resid if sep else np.vstack(resid)
-
-    def _chisqr(self, par, sep=False):
-        """
-        Calculate the error-normalized residual (close to the signed
-        chi-square metric) between the data and the current model.
-
-        Args:
-            par (`numpy.ndarray`_, optional):
-                The list of parameters to use. Length should be either
-                :attr:`np` or :attr:`nfree`. If the latter, the values of the
-                fixed parameters in :attr:`par` are used.
-            sep (:obj:`bool`, optional):
-                Return separate vectors for the velocity and velocity
-                dispersion residuals, instead of appending them.
-
-        Returns:
-            `numpy.ndarray`_: Difference between the data and the model for
-            all measurements, normalized by their errors.
-        """
-        vel, sig = self._binned_model(par)
-        if self.has_covar:
-            vfom = self._v_chisqr_covar(vel)
-            sfom = np.array([]) if self.dc is None else self._s_chisqr_covar(sig)
-        else:
-            vfom = self._v_chisqr(vel)
-            sfom = np.array([]) if self.dc is None else self._s_chisqr(sig)
-        return (vfom, sfom) if sep else np.append(vfom, sfom)
-
-    def _deriv_chisqr(self, par, sep=False):
-        """
-        Calculate the derivatives of the error-normalized residuals (close to
-        the signed chi-square metric) w.r.t. the *free* model parameters.
-
-        Args:
-            par (`numpy.ndarray`_, optional):
-                The list of parameters to use. Length should be either
-                :attr:`np` or :attr:`nfree`. If the latter, the values of the
-                fixed parameters in :attr:`par` are used.
-            sep (:obj:`bool`, optional):
-                Return separate vectors for the velocity and velocity
-                dispersion residuals, instead of appending them.
-
-        Returns:
-            :obj:`tuple`, `numpy.ndarray`_: Derivatives of the error-normalized
-            difference between the data and the model for all measurements
-            w.r.t. the *free* model parameters, either returned as a single
-            array for all data or as separate arrays for the velocity and
-            velocity dispersion data (based on ``sep``).
-        """
-        vel, sig, dvel, dsig = self._deriv_binned_model(par)
-        vf = self._deriv_v_chisqr_covar if self.has_covar else self._deriv_v_chisqr
-        if self.dc is None:
-            return (vf(dvel), numpy.array([])) if sep else vf(dvel)
-
-        sf = self._deriv_s_chisqr_covar if self.has_covar else self._deriv_s_chisqr
-        dchisqr = (vf(dvel), sf(sig, dsig))
-        if not np.all(np.isfinite(dchisqr[0])) or not np.all(np.isfinite(dchisqr[1])):
-            raise ValueError('Error in derivative computation.')
-        return dchisqr if sep else np.vstack(dchisqr)
-
-    def _fit_prep(self, kin, p0, fix, scatter, sb_wgt, assume_posdef_covar, ignore_covar, cnvfftw):
-        """
-        Prepare the object for fitting the provided kinematic data.
-
-        Args:
-            kin (:class:`~nirvana.data.kinematics.Kinematics`):
-                The object providing the kinematic data to be fit.
-            p0 (`numpy.ndarray`_):
-                The initial parameters for the model. Length must be
-                :attr:`np`.
-            fix (`numpy.ndarray`_):
-                A boolean array selecting the parameters that should be fixed
-                during the model fit.
-            scatter (:obj:`float`, optional):
-                Introduce a fixed intrinsic-scatter term into the model. This
-                single value is added in quadrature to all measurement errors
-                in the calculation of the merit function. If no errors are
-                available, this has the effect of renormalizing the
-                unweighted merit function by 1/scatter.
-            sb_wgt (:obj:`bool`):
-                Flag to use the surface-brightness data provided by ``kin``
-                to weight the model when applying the beam-smearing.
-            assume_posdef_covar (:obj:`bool`, optional):
-                If the :class:`~nirvana.data.kinematics.Kinematics` includes
-                covariance matrices, this forces the code to proceed assuming
-                the matrices are positive definite.
-            ignore_covar (:obj:`bool`, optional):
-                If the :class:`~nirvana.data.kinematics.Kinematics` includes
-                covariance matrices, ignore them and just use the inverse
-                variance.
-        """
-        # Initialize the fit parameters
-        self._init_par(p0, fix)
-        # Initialize the data to fit
-        self.kin = kin
-        self._init_coo(self.kin.grid_x, self.kin.grid_y)
-        self._init_sb(self.kin.grid_sb if sb_wgt else None)
-        self.vel_gpm = np.logical_not(self.kin.vel_mask)
-        self.sig_gpm = None if self.dc is None else np.logical_not(self.kin.sig_mask)
-        # Initialize the beam kernel
-        self._init_beam(self.kin.beam_fft, True, cnvfftw)
-
-        # Determine which errors were provided
-        self.has_err = self.kin.vel_ivar is not None if self.dc is None \
-                        else self.kin.vel_ivar is not None and self.kin.sig_ivar is not None
-        if not self.has_err and (self.kin.vel_err is not None or self.kin.sig_err is not None):
-            warnings.warn('Some errors being ignored if both velocity and velocity dispersion '
-                          'errors are not provided.')
-        self.has_covar = self.kin.vel_covar is not None if self.dc is None \
-                            else self.kin.vel_covar is not None and self.kin.sig_covar is not None
-        if not self.has_covar \
-                and (self.kin.vel_covar is not None or self.kin.sig_covar is not None):
-            warnings.warn('Some covariance matrices being ignored if both velocity and velocity '
-                          'dispersion covariances are not provided.')
-        if ignore_covar:
-            # Force ignoring the covariance
-            # TODO: This requires that, e.g., kin.vel_ivar also be defined...
-            self.has_covar = False
-
-        # Check the intrinsic scatter input
-        self.scatter = None
-        if scatter is not None:
-            self.scatter = np.atleast_1d(scatter)
-            if self.scatter.size > 2:
-                raise ValueError('Should provide, at most, one scatter term for each kinematic '
-                                 'moment being fit.')
-            if self.dc is not None and self.scatter.size == 1:
-                warnings.warn('Using single scatter term for both velocity and velocity '
-                              'dispersion.')
-                self.scatter = np.array([scatter, scatter])
-
-        # Set the internal error attributes
-        if self.has_err:
-            self._v_err = np.sqrt(inverse(self.kin.vel_ivar))
-            self._s_err = None if self.dc is None \
-                                else np.sqrt(inverse(self.kin.sig_phys2_ivar))
-            if self.scatter is not None:
-                self._v_err = np.sqrt(self._v_err**2 + self.scatter[0]**2)
-                if self.dc is not None:
-                    self._s_err = np.sqrt(self._s_err**2 + self.scatter[1]**2)
-        elif not self.has_err and not self.has_covar and self.scatter is not None:
-            self.has_err = True
-            self._v_err = np.full(self.kin.vel.shape, self.scatter[0], dtype=float)
-            self._s_err = None if self.dc is None \
-                                else np.full(self.kin.sig.shape, self.scatter[1], dtype=float)
-        else:
-            self._v_err = None
-            self._s_err = None
-
-        # Set the internal covariance attributes
-        if self.has_covar:
-            # Construct the matrices used to calculate the merit function in
-            # the presence of covariance.
-            vel_pd_covar = self.kin.vel_covar[np.ix_(self.vel_gpm,self.vel_gpm)]
-            sig_pd_covar = None if self.dc is None \
-                            else self.kin.sig_phys2_covar[np.ix_(self.sig_gpm,self.sig_gpm)]
-            if not assume_posdef_covar:
-                # Force the matrices to be positive definite
-                print('Forcing vel covar to be pos-def')
-                vel_pd_covar = impose_positive_definite(vel_pd_covar)
-                print('Forcing sig covar to be pos-def')
-                sig_pd_covar = None if self.dc is None else impose_positive_definite(sig_pd_covar)
-
-            if self.scatter is not None:
-                # A diagonal matrix with only positive values is, by definition,
-                # positive definite; and the sum of two positive-definite
-                # matrices is also positive definite.
-                vel_pd_covar += np.diag(np.full(vel_pd_covar.shape[0], self.scatter[0]**2,
-                                                dtype=float))
-                if self.dc is not None:
-                    sig_pd_covar += np.diag(np.full(sig_pd_covar.shape[0], self.scatter[1]**2,
-                                                    dtype=float))
-
-            self._v_ucov = cinv(vel_pd_covar, upper=True)
-            self._s_ucov = None if sig_pd_covar is None else cinv(sig_pd_covar, upper=True)
-        else:
-            self._v_ucov = None
-            self._s_ucov = None
-
-    def _get_fom(self):
-        """
-        Return the figure-of-merit function to use given the availability of
-        errors.
-        """
-        return self._chisqr if self.has_err or self.has_covar else self._resid
-
-    def _get_jac(self):
-        """
-        Return the Jacobian function to use given the availability of errors.
-        """
-        return self._deriv_chisqr if self.has_err or self.has_covar else self._deriv_resid
-
-    def lsq_fit(self, kin, sb_wgt=False, p0=None, fix=None, lb=None, ub=None, scatter=None,
-                verbose=0, assume_posdef_covar=False, ignore_covar=True, cnvfftw=None,
-                analytic_jac=True, maxiter=5):
-        """
-        """
-        if maxiter is None:
-            raise ValueError('Maximum number of iterations cannot be None.')
-
-        # Prepare to fit the data.
-        self._fit_prep(kin, p0, fix, scatter, sb_wgt, assume_posdef_covar, ignore_covar,
-                       cnvfftw)
-        
-        # Get the method used to generate the figure-of-merit and the Jacobian
-        # matrix.
-        fom = self._get_fom()
-        # If the analytic Jacobian matrix is not used, the derivative of the
-        # merit function wrt each parameter is determined by a 1% change in each
-        # parameter.
-        jac_kwargs = {'jac': self._get_jac()} if analytic_jac \
-                        else {'diff_step': np.full(self.np, 0.01, dtype=float)[self.free]}
-
-        # Parameter boundaries
-        _lb, _ub = self.par_bounds()
-        if lb is None:
-            lb = _lb
-        if ub is None:
-            ub = _ub
-        if len(lb) != self.np or len(ub) != self.np:
-            raise ValueError('Length of one or both of the bound vectors is incorrect.')
-
-        # Set the random number generator with a fixed seed so that the result
-        # is deterministic.
-        rng = np.random.default_rng(seed=909)
-        _p0 = self.par[self.free]
-        p = _p0.copy()
-        pe = None
-        niter = 0
-        while niter < maxiter:
-            # Run the optimization
-            result = optimize.least_squares(fom, p, # method='lm', #xtol=None,
-                                            x_scale='jac', method='trf', xtol=1e-12,
-                                            bounds=(lb[self.free], ub[self.free]), 
-                                            verbose=max(verbose,0), **jac_kwargs)
-            try:
-                pe = np.sqrt(np.diag(cov_err(result.jac)))
-            except:
-                warnings.warn('Unable to compute parameter errors from precision matrix.')
-                pe = None
-
-            # The fit should change the input parameters.
-            if np.all(np.absolute(p-result.x) > 1e-3):
-                break
-
-            # If it doesn't, something likely went wrong with the fit.  Perturb
-            # the input guesses a bit and retry.
-            p = _p0 + rng.normal(size=self.nfree)*(pe if pe is not None else 0.1*p0)
-            p = np.clip(p, lb[self.free], ub[self.free])
-            niter += 1
-
-        # TODO: Add something to the fit status/success flags that tests if
-        # niter == maxiter and/or if the input parameters are identical to the
-        # final best-fit prameters?  Note that the input parameters, p0, may not
-        # be identical to the output parameters because of the iterations mean
-        # that p != p0 !
-
-        # Save the fit status
-        self.fit_status = result.status
-        self.fit_success = result.success
-
-        # Save the best-fitting parameters
-        self._set_par(result.x)
-        if pe is None:
-            self.par_err = None
-        else:
-            self.par_err = np.zeros(self.np, dtype=float)
-            self.par_err[self.free] = pe
-
-        # Print the report
-        if verbose > -1:
-            self.report(fit_message=result.message)
-
-
     def report(self, fit_message=None):
         """
         Report the current parameters of the model.
@@ -1680,6 +1061,9 @@ class BisymmetricDisk:
         for i in range(ps,pe):
             print(('{0:>'+f'{max_parn_len}'+'}'+ f': {self.par[i]:.1f}').format(parn[i])
                     + (f'' if self.par_err is None else f' +/- {self.par_err[i]:.1f}'))
+        # Bisymmetry angle
+        print(('{0:>'+f'{max_parn_len}'+'}'+ f': {self.par[pe]:.1f}').format(parn[pe])
+                + (f'' if self.par_err is None else f' +/- {self.par_err[pe]:.1f}'))
         print('-'*10)
 
         print(f'First-order tangential speed parameters:')

--- a/nirvana/models/thindisk.py
+++ b/nirvana/models/thindisk.py
@@ -20,8 +20,46 @@ from .util import cov_err
 from ..data.kinematics import Kinematics
 from ..data.util import impose_positive_definite, cinv, inverse
 from ..data.util import select_major_axis, bin_stats, growth_lim, atleast_one_decade
+from ..util.bitmask import BitMask
 
 #warnings.simplefilter('error', RuntimeWarning)
+
+class ThinDiskFitBitMask(BitMask):
+    """
+    Bin-by-bin mask used to track fit rejections.
+    """
+    def __init__(self):
+        # TODO: np.array just used for slicing convenience
+        mask_def = np.array([['DIDNOTUSE', 'Data not used because it was flagged on input.'],
+                             ['REJ_ERR', 'Data rejected because of its large measurement error.'],
+                             ['REJ_SNR', 'Data rejected because of its low signal-to-noise.'],
+                             ['REJ_UNR', 'Data rejected after first iteration and are so '
+                                         'discrepant from the other data that we expect the '
+                                         'measurements are unreliable.'],
+                             ['REJ_RESID', 'Data rejected due to iterative rejection process '
+                                           'of model residuals.'],
+                             ['DISJOINT', 'Data part of a smaller disjointed region, not '
+                                          'congruent with the main body of the measurements.']])
+        super().__init__(mask_def[:,0], descr=mask_def[:,1])
+
+    @staticmethod
+    def base_flags():
+        """
+        Return the list of "base-level" flags that are *always* ignored,
+        regardless of the fit iteration.
+        """
+        return ['DIDNOTUSE', 'REJ_ERR', 'REJ_SNR', 'REJ_UNR', 'DISJOINT']
+
+
+class ThinDiskGlobalBitMask(BitMask):
+    """
+    Fit-wide quality flag.
+    """
+    def __init__(self):
+        # NOTE: np.array just used for slicing convenience
+        mask_def = np.array([['LOWINC', 'Fit has an erroneously low inclination']])
+        super().__init__(mask_def[:,0], descr=mask_def[:,1])
+
 
 class ThinDisk:
     r"""
@@ -45,6 +83,17 @@ class ThinDisk:
         Describe the attributes
 
     """
+
+    gbm = ThinDiskGlobalBitMask()
+    """
+    Global bitmask.
+    """
+
+    mbm = ThinDiskFitBitMask()
+    """
+    Measurement-specific bitmask.
+    """
+
     def __init__(self, **kwargs):
         # Number of "base" parameters
         self.nbp = 5
@@ -1375,4 +1424,117 @@ class ThinDisk:
                 The status message returned by the fit optimization.
         """
         pass
+
+    # TODO: This currently requires errors.  Allow for rejection without
+    # errors...
+    def reject(self, disp=None, ignore_covar=True, vel_sigma_rej=5, show_vel=False, vel_plot=None,
+               sig_sigma_rej=5, show_sig=False, sig_plot=None, verbose=False):
+        """
+        Reject kinematic data based on the error-weighted residuals with respect
+        to the current disk.
+
+        The method requires that the kinematic data already be ingested
+        (:attr:`kin`) and that the model parameters have been set (:attr:`par`).
+
+        The rejection iteration is done using
+        :class:`~nirvana.data.scatter.IntrinsicScatter`, independently for the
+        velocity and velocity dispersion measurements (if the latter is selected
+        and/or available).
+
+        Note that you can both show the QA plots and have them written to a file
+        (e.g., ``show_vel`` can be True and ``vel_plot`` can provide a file).
+
+        Args:
+            disp (:obj:`bool`, optional):
+                Flag to include the velocity dispersion rejection in the
+                iteration.  If None, rejection is included if :attr:`kin` has
+                velocity dispersion data and a dispersion parameterization is
+                available (:attr:`dc`).
+            ignore_covar (:obj:`bool`, optional):
+                If :attr:`kin` provides the covariance between measurements,
+                ignore it when constructing the error-weighted residuals.
+            vel_sigma_rej (:obj:`float`, optional):
+                Rejection sigma for the velocity measurements.  If None, no data are
+                rejected and the function basically just measures the intrinsic
+                scatter.
+            show_vel (:obj:`bool`, optional):
+                Show the QA plot for the velocity rejection (see
+                :func:`~nirvana.data.scatter.IntrinsicScatter.show`).
+            vel_plot (:obj:`str`, optional):
+                Write the QA plot for the velocity rejection to this file (see
+                :func:`~nirvana.data.scatter.IntrinsicScatter.show`).
+            sig_sigma_rej (:obj:`float`, optional):
+                Rejection sigma for the dispersion measurements.  If None, no data
+                are rejected and the function basically just measures the intrinsic
+                scatter.
+            show_sig (:obj:`bool`, optional):
+                Show the QA plot for the velocity dispersion rejection (see
+                :func:`~nirvana.data.scatter.IntrinsicScatter.show`).
+            sig_plot (:obj:`str`, optional):
+                Write the QA plot for the velocity dispersion rejection to this
+                file (see :func:`~nirvana.data.scatter.IntrinsicScatter.show`).
+            verbose (:obj:`bool`, optional):
+                Verbose scatter fitting output.
+
+        Returns:
+            :obj:`tuple`: Returns two pairs of objects, one for each kinematic
+            moment. The first object is the vector flagging the data that should
+            be rejected and the second is the estimated intrinsic scatter about
+            the model. If the dispersion is not included in the rejection, the
+            last two objects returned are both None.
+        """
+
+        # Check input
+        if disp is None:
+            disp = kin.sig is not None and self.dc is not None
+        if disp and (kin.sig is None or self.dc is None):
+            raise ValueError('Cannot include dispersion if there is no dispersion data or if the '
+                             'dispersion data were not fit by the model.')
+        use_covar = not ignore_covar and kin.vel_covar is not None
+        if disp:
+            use_covar = use_covar and kin.sig_phys2_covar is not None
+
+        # Get the models; this assumes the parameters are already set!
+        models = self.model()
+        _verbose = 2 if verbose else 0
+
+        # Reject based on error-weighted residuals, accounting for intrinsic
+        # scatter
+        vmod = models[0] if len(models) == 2 else models
+        resid = kin.vel - kin.bin(vmod)
+        v_err_kwargs = {'covar': kin.vel_covar} if use_covar \
+                            else {'err': np.sqrt(inverse(kin.vel_ivar))}
+        scat = IntrinsicScatter(resid, gpm=disk.vel_gpm, npar=disk.nfree, **v_err_kwargs)
+        vel_sig, vel_rej, vel_gpm = scat.iter_fit(sigma_rej=vel_sigma_rej, fititer=5, verbose=_verbose)
+#        # Incorporate into mask
+#        if vel_mask is not None and np.any(vel_rej):
+#            vel_mask[vel_rej] = disk.mbm.turn_on(vel_mask[vel_rej], rej_flag)
+
+        # Show and/or plot the result, if requested
+        if show_vel:
+            scat.show()
+        if vel_plot is not None:
+            scat.show(ofile=vel_plot)
+
+        if not disp:
+            # Not rejecting dispersion so we're done
+            return vel_rej, vel_sig, None, None
+
+        # Reject based on error-weighted residuals, accounting for intrinsic
+        # scatter
+        resid = kin.sig_phys2 - kin.bin(models[1])**2
+        sig_err_kwargs = {'covar': kin.sig_phys2_covar} if use_covar \
+                            else {'err': np.sqrt(inverse(kin.sig_phys2_ivar))}
+        scat = IntrinsicScatter(resid, gpm=disk.sig_gpm, npar=disk.nfree, **sig_err_kwargs)
+        sig_sig, sig_rej, sig_gpm = scat.iter_fit(sigma_rej=sig_sigma_rej, fititer=5, verbose=_verbose)
+#        # Incorporate into mask
+#        if sig_mask is not None and np.any(sig_rej):
+#            sig_mask[sig_rej] = disk.mbm.turn_on(sig_mask[sig_rej], rej_flag)
+        # Show and/or plot the result, if requested
+        if show_sig:
+            scat.show()
+        if sig_plot is not None:
+            scat.show(ofile=sig_plot)
+
+        return vel_rej, vel_sig, sig_rej, sig_sig
 

--- a/nirvana/models/thindisk.py
+++ b/nirvana/models/thindisk.py
@@ -1,0 +1,1378 @@
+"""
+Base class for thin disk models.
+
+.. include common links, assuming primary doc root is up one directory
+.. include:: ../include/links.rst
+"""
+
+import os
+import warnings
+
+from IPython import embed
+
+import numpy as np
+from scipy import optimize
+
+from astropy.io import fits
+
+from .beam import ConvolveFFTW, smear, deriv_smear
+from .util import cov_err
+from ..data.kinematics import Kinematics
+from ..data.util import impose_positive_definite, cinv, inverse
+from ..data.util import select_major_axis, bin_stats, growth_lim, atleast_one_decade
+
+#warnings.simplefilter('error', RuntimeWarning)
+
+class ThinDisk:
+    r"""
+    Provides a base class for razor-thin disk models.
+
+    The model assumes the disk is infinitely thin and has a single set of
+    geometric and bulk-flow parameters:
+
+        - :math:`x_c, y_c`: The coordinates of the galaxy dynamical center.
+        - :math:`\phi`: The position angle of the galaxy (the angle from N
+          through E)
+        - :math:`i`: The inclination of the disk; the angle of the disk
+          normal relative to the line-of-sight such that :math:`i=0` is a
+          face-on disk.
+        - :math:`V_{\rm sys}`: The systemic (bulk) velocity of the galaxy
+          taken as the line-of-sight velocity at the dynamical center.
+
+    Other than that, this is an abstract base class.
+
+    .. todo::
+        Describe the attributes
+
+    """
+    def __init__(self, **kwargs):
+        # Number of "base" parameters
+        self.nbp = 5
+        # Initialize common attributes
+        self.reinit()
+
+    def __repr__(self):
+        """
+        Provide the representation of the object when written to the screen.
+        """
+        # Collect the attributes relevant to construction of a model
+        attr = [n for n in ['par', 'x', 'y', 'sb', 'beam_fft'] if getattr(self, n) is not None]
+        return f'<{self.__class__.__name__}: Defined attr - {",".join(attr)}>'
+
+    def reinit(self):
+        """
+        Reinitialize the object.
+
+        This resets the model parameters to the guess parameters and erases any
+        existing data used to construct the models.  Note that, just like when
+        instantiating a new object, any calls to :func:`model` after
+        reinitialization will require at least the coordinates (``x`` and ``y``)
+        to be provided to successfully calculate the model.
+        """
+        self.par = self.guess_par() # Model parameters
+        self.par_err = None         # Model parameter errors
+        self.x = None               # On-sky coordinates at which to evaluate the model
+        self.y = None
+        self.beam_fft = None        # FFT of the beam kernel
+        self.kin = None             # Kinematics object with data to fit
+        self.sb = None              # Surface-brightness weighting for each x,y position
+        self.vel_gpm = None         # "Good-pixel mask" for velocity measurements
+        self.sig_gpm = None         # "Good-pixel mask" for dispersion measurements
+        self.cnvfftw = None         # ConvolveFFTW object used to perform convolutions
+        self.global_mask = 0        # Global bitmask value
+        self.fit_status = None      # Status integer for a fit
+        self.fit_success = None     # Flag that a fit was successful
+
+    def guess_par(self):
+        """
+        Return a list of generic guess parameters.
+
+        .. todo::
+            Could enable this to base the guess on the data to be fit, but at
+            the moment these are hard-coded numbers.
+
+        Returns:
+            `numpy.ndarray`_: Vector of guess parameters
+        """
+        # Return the guess parameters for the geometric parameters
+        return np.array([0., 0., 45., 30., 0.])
+
+    def par_names(self, short=False):
+        """
+        Return a list of strings with the parameter names.
+
+        Args:
+            short (:obj:`bool`, optional):
+                Return truncated nomenclature for the parameter names.
+
+        Returns:
+            :obj:`list`: List of parameter name strings.
+        """
+        if short:
+            return ['x0', 'y0', 'pa', 'inc', 'vsys']
+        return ['X center', 'Y center', 'Position Angle', 'Inclination', 'Systemic Velocity']
+
+    def _base_slice(self):
+        """
+        Return a slice object used to select the base parameters from the
+        parameter vector.
+        """
+        return slice(self.nbp)
+
+    def base_par(self, err=False):
+        """
+        Return the base (largely geometric) parameters. Returns None if
+        parameters are not defined yet.
+
+        Args:
+            err (:obj:`bool`, optional):
+                Return the parameter errors instead of the parameter values.
+
+        Returns:
+            `numpy.ndarray`_: Vector with parameters or parameter errors for the
+            "base" parameters.
+        """
+        p = self.par_err if err else self.par
+        return None if p is None else p[self._base_slice()]
+
+    def par_bounds(self, base_lb=None, base_ub=None):
+        """
+        Return the lower and upper boundaries on the model parameters.
+
+        The default geometric bounds (see ``base_lb``, ``base_ub``) are set
+        by the minimum and maximum available x and y coordinates, -350 to 350
+        for the position angle, 1 to 89 for the inclination, and -300 to 300
+        for the systemic velocity.
+
+        .. todo::
+
+            Could enable this to base the bounds on the data to be fit, but
+            at the moment these are hard-coded numbers.
+
+        Args:
+            base_lb (`numpy.ndarray`_, optional):
+                The lower bounds for the "base" parameters: x0, y0, pa, inc,
+                vsys. If None, the defaults are used (see above).
+            base_ub (`numpy.ndarray`_, optional):
+                The upper bounds for the "base" parameters: x0, y0, pa, inc,
+                vsys. If None, the defaults are used (see above).
+
+        Returns:
+            :obj:`tuple`: A two-tuple providing, respectively, the lower and
+            upper boundaries for all model parameters.
+        """
+        if base_lb is not None and len(base_lb) != self.nbp:
+            raise ValueError('Incorrect number of lower bounds for the base '
+                             f'parameters; found {len(base_lb)}, expected {self.nbp}.')
+        if base_ub is not None and len(base_ub) != self.nbp:
+            raise ValueError('Incorrect number of upper bounds for the base '
+                             f'parameters; found {len(base_ub)}, expected {self.nbp}.')
+
+        if (base_lb is None or base_ub is None) and (self.x is None or self.y is None):
+            raise ValueError('Cannot define limits on center.  Provide base_lb,base_ub or set '
+                             'the evaluation grid coordinates (attributes x and y).')
+
+        if base_lb is None:
+            minx = np.amin(self.x)
+            miny = np.amin(self.y)
+            base_lb = np.array([minx, miny, -350., 1., -300.])
+        if base_ub is None:
+            maxx = np.amax(self.x)
+            maxy = np.amax(self.y)
+            base_ub = np.array([maxx, maxy, 350., 89., 300.])
+        return (base_lb, base_ub)
+
+    def _set_par(self, par):
+        """
+        Set the full parameter vector, accounting for any fixed parameters.
+
+        Args:
+            par (`numpy.ndarray`_, optional):
+                The list of parameters to use. Length should be either
+                :attr:`np` or :attr:`nfree`. If the latter, the values of the
+                fixed parameters in :attr:`par` are used.
+        """
+        # WARNING: The nfree and free *must* be part of the derived class.
+        if par.ndim != 1:
+            raise ValueError('Parameter array must be a 1D vector.')
+        if par.size == self.np:
+            self.par = par.copy()
+            return
+        if par.size != self.nfree:
+            raise ValueError('Must provide {0} or {1} parameters.'.format(self.np, self.nfree))
+        self.par[self.free] = par.copy()
+
+    def _init_coo(self, x, y):
+        """
+        Initialize the coordinate arrays.
+
+        .. warning::
+            
+            Input coordinate data types are all converted to `numpy.float64`_.
+            This is always true, even though this is only needed when using
+            :class:`~nirvana.models.beam.ConvolveFFTW`.
+
+        Args:
+            x (`numpy.ndarray`_):
+                The 2D x-coordinates at which to evaluate the model.  If not
+                None, replace the existing :attr:`x` with this array.
+            y (`numpy.ndarray`_):
+                The 2D y-coordinates at which to evaluate the model.  If not
+                None, replace the existing :attr:`y` with this array.
+
+        Raises:
+            ValueError:
+                Raised if the shapes of :attr:`x` and :attr:`y` are not the same.
+        """
+        if x is None and y is None:
+            # Nothing to do
+            return
+
+        # Define it and check it
+        if x is not None:
+            self.x = x.astype(float)
+        if y is not None:
+            self.y = y.astype(float)
+        if self.x.shape != self.y.shape:
+            raise ValueError('Input coordinates must have the same shape.')
+
+    def _init_sb(self, sb):
+        """
+        Initialize the surface brightness array.
+
+        .. warning::
+            
+            Input surface-brightness data types are all converted to
+            `numpy.float64`_.  This is always true, even though this is only
+            needed when using :class:`~nirvana.models.beam.ConvolveFFTW`.
+
+        Args:
+            sb (`numpy.ndarray`_):
+                2D array with the surface brightness of the object.  If not
+                None, replace the existing :attr:`sb` with this array.
+
+        Raises:
+            ValueError:
+                Raised if the shapes of :attr:`sb` and :attr:`x` are not the same.
+        """
+        if sb is None:
+            # Nothing to do
+            return
+
+        # Check it makes sense to define the surface brightness
+        if self.x is None:
+            raise ValueError('Input coordinates must be instantiated first!')
+
+        # Define it and check it
+        self.sb = sb.astype(float)
+        if self.sb.shape != self.x.shape:
+            raise ValueError('Input coordinates must have the same shape.')
+
+    def _init_beam(self, beam, is_fft, cnvfftw):
+        """
+        Initialize the beam-smearing kernel and the convolution method.
+
+        Args:
+            beam (`numpy.ndarray`_):
+                The 2D rendering of the beam-smearing kernel, or its Fast
+                Fourier Transform (FFT).  If not None, replace existing
+                :attr:`beam_fft` with this array (or its FFT, depending on the
+                provided ``is_fft``).
+            is_fft (:obj:`bool`):
+                The provided ``beam`` object is already the FFT of the
+                beam-smearing kernel.
+            cnvfftw (:class:`~nirvana.models.beam.ConvolveFFTW`):
+                An object that expedites the convolutions using FFTW/pyFFTW.  If
+                provided, the shape *must* match :attr:``beam_fft`` (after this
+                is potentially updated by the provided ``beam``).  If None, a
+                new :class:`~nirvana.models.beam.ConvolveFFTW` instance is
+                constructed to perform the convolutions.  If the class cannot be
+                constructed because the user doesn't have pyfftw installed, then
+                the convolutions fall back to the numpy routines.
+        """
+        if beam is None:
+            # Nothing to do
+            return
+
+        # Check it makes sense to define the beam
+        if self.x is None:
+            raise ValueError('Input coordinates must be instantiated first!')
+        if self.x.ndim != 2:
+            raise ValueError('To perform convolution, must provide 2d coordinate arrays.')
+
+        # Assign the beam and check it
+        self.beam_fft = beam if is_fft else np.fft.fftn(np.fft.ifftshift(beam))
+        if self.beam_fft.shape != self.x.shape:
+            raise ValueError('Currently, convolution requires the beam map to have the same '
+                                'shape as the coordinate maps.')
+
+        # Convolutions will be performed, try to setup the ConvolveFFTW
+        # object (self.cnvfftw).
+        if cnvfftw is None:
+            if self.cnvfftw is not None and self.cnvfftw.shape == self.beam_fft.shape:
+                # ConvolveFFTW is ready to go
+                return
+
+            try:
+                self.cnvfftw = ConvolveFFTW(self.beam_fft.shape)
+            except:
+                warnings.warn('Could not instantiate ConvolveFFTW; proceeding with numpy '
+                              'FFT/convolution routines.')
+                self.cnvfftw = None
+        else:
+            # A cnvfftw was provided, check it
+            if not isinstance(cnvfftw, ConvolveFFTW):
+                raise TypeError('Provided cnvfftw must be a ConvolveFFTW instance.')
+            if cnvfftw.shape != self.beam_fft.shape:
+                raise ValueError('cnvfftw shape does not match beam shape.')
+            self.cnvfftw = cnvfftw
+
+    def _init_par(self, p0, fix):
+        """
+        Initialize the relevant parameter vectors that tracks the full set of
+        model parameters and which of those are freely fit by the model.
+
+        Args:
+            p0 (`numpy.ndarray`_):
+                The initial parameters for the model.  Can be None.  Length must
+                be :attr:`np`, if not None.
+            fix (`numpy.ndarray`_):
+                A boolean array selecting the parameters that should be fixed
+                during the model fit.  Can be None.  Length must be :attr:`np`,
+                if not None.
+        """
+        if p0 is None:
+            p0 = self.guess_par()
+        _p0 = np.atleast_1d(p0)
+        if _p0.size != self.np:
+            raise ValueError('Incorrect number of model parameters.')
+        self.par = _p0.copy()
+        self.par_err = None
+        _free = np.ones(self.np, dtype=bool) if fix is None else np.logical_not(fix)
+        if _free.size != self.np:
+            raise ValueError('Incorrect number of model parameter fitting flags.')
+        self.free = _free.copy()
+        self.nfree = np.sum(self.free)
+
+    def _init_model(self, par, x, y, sb, beam, is_fft, cnvfftw, ignore_beam):
+        """
+        Initialize the attributes in preparation of a model calculation.
+
+        Args:
+            par (`numpy.ndarray`_):
+                The list of parameters to use. If None, the internal
+                :attr:`par` is used. Length should be either :attr:`np` or
+                :attr:`nfree`. If the latter, the values of the fixed
+                parameters in :attr:`par` are used.  See :func:`_set_par`.
+            x (`numpy.ndarray`_):
+                The 2D x-coordinates at which to evaluate the model. If None,
+                the internal :attr:`x` is used. See :func:`_init_coo`.
+            y (`numpy.ndarray`_):
+                The 2D y-coordinates at which to evaluate the model. If None,
+                the internal :attr:`y` is used. See :func:`_init_coo`.
+            sb (`numpy.ndarray`_):
+                2D array with the surface brightness of the object. This is used
+                to weight the convolution of the kinematic fields according to
+                the luminosity distribution of the object.  Must have the same
+                shape as ``x``. If None, the internal :attr:`sb` is used or, if
+                that is also None, the convolution is unweighted.  If a
+                convolution is not performed (either ``beam`` or
+                :attr:`beam_fft` are not available, or ``ignore_beam`` is True),
+                this array is ignored.  See :func:`_init_sb`.
+            beam (`numpy.ndarray`_):
+                The 2D rendering of the beam-smearing kernel, or its Fast
+                Fourier Transform (FFT). If None, the internal :attr:`beam_fft`
+                is used.  See :func:`_init_beam`.
+            is_fft (:obj:`bool`):
+                The provided ``beam`` object is already the FFT of the
+                beam-smearing kernel.  See :func:`_init_beam`.
+            cnvfftw (:class:`~nirvana.models.beam.ConvolveFFTW`):
+                An object that expedites the convolutions using
+                FFTW/pyFFTW.  See :func:`_init_beam`.
+            ignore_beam (:obj:`bool`):
+                Ignore the beam-smearing when constructing the model. I.e.,
+                construct the *intrinsic* model.
+        """
+        # Initialize the coordinates (this does nothing if both x and y are None)
+        self._init_coo(x, y)
+        # Initialize the convolution kernel (this does nothing if beam is None)
+        self._init_beam(beam, is_fft, cnvfftw)
+        if self.beam_fft is not None and not ignore_beam:
+            # Initialize the surface brightness, only if it would be used
+            self._init_sb(sb)
+        # Check that the model can be calculated
+        if self.x is None or self.y is None:
+            raise ValueError('No coordinate grid defined.')
+        # Reset the parameter values
+        if par is not None:
+            self._set_par(par)
+
+    def _init_data(self, kin, scatter, assume_posdef_covar, ignore_covar):
+        """
+        Initialize the data attributes needed for fitting the data with this model.
+
+        Args:
+            kin (:class:`~nirvana.data.kinematics.Kinematics`):
+                The object providing the kinematic data to be fit.
+            scatter (:obj:`float`, array-like):
+                Introduce a fixed intrinsic-scatter term into the model. The 
+                scatter is added in quadrature to all measurement errors in the
+                calculation of the merit function. If no errors are available,
+                this has the effect of renormalizing the unweighted merit
+                function by 1/scatter.  Can be None, which means no intrinsic
+                scatter is added.  If both velocity and velocity dispersion are
+                being fit, this can be a single number applied to both datasets
+                or a 2-element vector that provides different intrinsic scatter
+                measurements for each kinematic moment (ordered velocity then
+                velocity dispersion).
+            assume_posdef_covar (:obj:`bool`):
+                If the :class:`~nirvana.data.kinematics.Kinematics` includes
+                covariance matrices, this forces the code to proceed assuming
+                the matrices are positive definite.
+            ignore_covar (:obj:`bool`):
+                If the :class:`~nirvana.data.kinematics.Kinematics` includes
+                covariance matrices, ignore them and just use the inverse
+                variance.
+        """
+        # Initialize the data to fit
+        self.kin = kin
+        self.vel_gpm = np.logical_not(self.kin.vel_mask)
+        self.sig_gpm = None if self.dc is None else np.logical_not(self.kin.sig_mask)
+
+        # Determine which errors were provided
+        self.has_err = self.kin.vel_ivar is not None if self.dc is None \
+                        else self.kin.vel_ivar is not None and self.kin.sig_ivar is not None
+        if not self.has_err and (self.kin.vel_err is not None or self.kin.sig_err is not None):
+            warnings.warn('Some errors being ignored if both velocity and velocity dispersion '
+                          'errors are not provided.')
+        self.has_covar = self.kin.vel_covar is not None if self.dc is None \
+                            else self.kin.vel_covar is not None and self.kin.sig_covar is not None
+        if not self.has_covar \
+                and (self.kin.vel_covar is not None or self.kin.sig_covar is not None):
+            warnings.warn('Some covariance matrices being ignored if both velocity and velocity '
+                          'dispersion covariances are not provided.')
+        if ignore_covar:
+            # Force ignoring the covariance
+            # TODO: This requires that, e.g., kin.vel_ivar also be defined...
+            self.has_covar = False
+
+        # Check the intrinsic scatter input
+        self.scatter = None
+        if scatter is not None:
+            self.scatter = np.atleast_1d(scatter)
+            if self.scatter.size > 2:
+                raise ValueError('Should provide, at most, one scatter term for each kinematic '
+                                 'moment being fit.')
+            if self.dc is not None and self.scatter.size == 1:
+                warnings.warn('Using single scatter term for both velocity and velocity '
+                              'dispersion.')
+                self.scatter = np.array([scatter, scatter])
+
+        # Set the internal error attributes
+        if self.has_err:
+            self._v_err = np.sqrt(inverse(self.kin.vel_ivar))
+            self._s_err = None if self.dc is None \
+                                else np.sqrt(inverse(self.kin.sig_phys2_ivar))
+            if self.scatter is not None:
+                self._v_err = np.sqrt(self._v_err**2 + self.scatter[0]**2)
+                if self.dc is not None:
+                    self._s_err = np.sqrt(self._s_err**2 + self.scatter[1]**2)
+        elif not self.has_err and not self.has_covar and self.scatter is not None:
+            self.has_err = True
+            self._v_err = np.full(self.kin.vel.shape, self.scatter[0], dtype=float)
+            self._s_err = None if self.dc is None \
+                                else np.full(self.kin.sig.shape, self.scatter[1], dtype=float)
+        else:
+            self._v_err = None
+            self._s_err = None
+
+        # Set the internal covariance attributes
+        if self.has_covar:
+            # Construct the matrices used to calculate the merit function in
+            # the presence of covariance.
+            vel_pd_covar = self.kin.vel_covar[np.ix_(self.vel_gpm,self.vel_gpm)]
+            sig_pd_covar = None if self.dc is None \
+                            else self.kin.sig_phys2_covar[np.ix_(self.sig_gpm,self.sig_gpm)]
+            if not assume_posdef_covar:
+                # Force the matrices to be positive definite
+                print('Forcing vel covar to be pos-def')
+                vel_pd_covar = impose_positive_definite(vel_pd_covar)
+                print('Forcing sig covar to be pos-def')
+                sig_pd_covar = None if self.dc is None else impose_positive_definite(sig_pd_covar)
+
+            if self.scatter is not None:
+                # A diagonal matrix with only positive values is, by definition,
+                # positive definite; and the sum of two positive-definite
+                # matrices is also positive definite.
+                vel_pd_covar += np.diag(np.full(vel_pd_covar.shape[0], self.scatter[0]**2,
+                                                dtype=float))
+                if self.dc is not None:
+                    sig_pd_covar += np.diag(np.full(sig_pd_covar.shape[0], self.scatter[1]**2,
+                                                    dtype=float))
+
+            self._v_ucov = cinv(vel_pd_covar, upper=True)
+            self._s_ucov = None if sig_pd_covar is None else cinv(sig_pd_covar, upper=True)
+        else:
+            self._v_ucov = None
+            self._s_ucov = None
+
+    def model(self, par=None, x=None, y=None, sb=None, beam=None, is_fft=False, cnvfftw=None,
+              ignore_beam=False):
+        """
+        Evaluate the model.
+
+        Note that arguments passed to this function overwrite any existing
+        attributes of the object, and subsequent calls to this function will
+        continue to use existing attributes, unless they are overwritten.  For
+        example, if ``beam`` is provided here, it overwrites any existing
+        :attr:`beam_fft` and any subsequent calls to ``model`` **that do not
+        provide a new** ``beam`` will use the existing :attr:`beam_fft`.  To
+        remove all internal attributes to get a "clean" instantiation, either
+        define a new :class:`AxisymmetricDisk` instance or use :func:`reinit`.
+
+        .. warning::
+            
+            Input coordinates and surface-brightness data types are all
+            converted to `numpy.float64`_.  This is always true, even though
+            this is only needed when using
+            :class:`~nirvana.models.beam.ConvolveFFTW`.
+
+        Args:
+            par (`numpy.ndarray`_, optional):
+                The list of parameters to use. If None, the internal
+                :attr:`par` is used. Length should be either :attr:`np` or
+                :attr:`nfree`. If the latter, the values of the fixed
+                parameters in :attr:`par` are used.
+            x (`numpy.ndarray`_, optional):
+                The 2D x-coordinates at which to evaluate the model. If not
+                provided, the internal :attr:`x` is used.
+            y (`numpy.ndarray`_, optional):
+                The 2D y-coordinates at which to evaluate the model. If not
+                provided, the internal :attr:`y` is used.
+            sb (`numpy.ndarray`_, optional):
+                2D array with the surface brightness of the object. This is used
+                to weight the convolution of the kinematic fields according to
+                the luminosity distribution of the object.  Must have the same
+                shape as ``x``. If None, the convolution is unweighted.  If a
+                convolution is not performed (either ``beam`` or
+                :attr:`beam_fft` are not available, or ``ignore_beam`` is True),
+                this array is ignored.
+            beam (`numpy.ndarray`_, optional):
+                The 2D rendering of the beam-smearing kernel, or its Fast
+                Fourier Transform (FFT). If not provided, the internal
+                :attr:`beam_fft` is used.
+            is_fft (:obj:`bool`, optional):
+                The provided ``beam`` object is already the FFT of the
+                beam-smearing kernel.  Ignored if ``beam`` is not provided.
+            cnvfftw (:class:`~nirvana.models.beam.ConvolveFFTW`, optional):
+                An object that expedites the convolutions using
+                FFTW/pyFFTW. If None, the convolution is done using numpy
+                FFT routines.
+            ignore_beam (:obj:`bool`, optional):
+                Ignore the beam-smearing when constructing the model. I.e.,
+                construct the *intrinsic* model.
+
+        Returns:
+            `numpy.ndarray`_, :obj:`tuple`: The velocity field model, and the
+            velocity dispersion field model, if the latter is included
+        """
+        raise NotImplementedError(f'Model not implemented for {self.__class__.__name__}')
+
+    def deriv_model(self, par=None, x=None, y=None, sb=None, beam=None, is_fft=False, cnvfftw=None,
+                    ignore_beam=False):
+        """
+        Evaluate the derivative of the model w.r.t all input parameters.
+
+        Note that arguments passed to this function overwrite any existing
+        attributes of the object, and subsequent calls to this function will
+        continue to use existing attributes, unless they are overwritten.  For
+        example, if ``beam`` is provided here, it overwrites any existing
+        :attr:`beam_fft` and any subsequent calls to ``model`` **that do not
+        provide a new** ``beam`` will use the existing :attr:`beam_fft`.  To
+        remove all internal attributes to get a "clean" instantiation, either
+        define a new :class:`AxisymmetricDisk` instance or use :func:`reinit`.
+
+        .. warning::
+            
+            Input coordinates and surface-brightness data types are all
+            converted to `numpy.float64`_.  This is always true, even though
+            this is only needed when using
+            :class:`~nirvana.models.beam.ConvolveFFTW`.
+
+        Args:
+            par (`numpy.ndarray`_, optional):
+                The list of parameters to use. If None, the internal
+                :attr:`par` is used. Length should be either :attr:`np` or
+                :attr:`nfree`. If the latter, the values of the fixed
+                parameters in :attr:`par` are used.
+            x (`numpy.ndarray`_, optional):
+                The 2D x-coordinates at which to evaluate the model. If not
+                provided, the internal :attr:`x` is used.
+            y (`numpy.ndarray`_, optional):
+                The 2D y-coordinates at which to evaluate the model. If not
+                provided, the internal :attr:`y` is used.
+            sb (`numpy.ndarray`_, optional):
+                2D array with the surface brightness of the object. This is used
+                to weight the convolution of the kinematic fields according to
+                the luminosity distribution of the object.  Must have the same
+                shape as ``x``. If None, the convolution is unweighted.  If a
+                convolution is not performed (either ``beam`` or
+                :attr:`beam_fft` are not available, or ``ignore_beam`` is True),
+                this array is ignored.
+            beam (`numpy.ndarray`_, optional):
+                The 2D rendering of the beam-smearing kernel, or its Fast
+                Fourier Transform (FFT). If not provided, the internal
+                :attr:`beam_fft` is used.
+            is_fft (:obj:`bool`, optional):
+                The provided ``beam`` object is already the FFT of the
+                beam-smearing kernel.  Ignored if ``beam`` is not provided.
+            cnvfftw (:class:`~nirvana.models.beam.ConvolveFFTW`, optional):
+                An object that expedites the convolutions using
+                FFTW/pyFFTW. If None, the convolution is done using numpy
+                FFT routines.
+            ignore_beam (:obj:`bool`, optional):
+                Ignore the beam-smearing when constructing the model. I.e.,
+                construct the *intrinsic* model.
+
+        Returns:
+            `numpy.ndarray`_, :obj:`tuple`: The velocity field model, and the
+            velocity dispersion field model, if the latter is included
+        """
+        raise NotImplementedError(f'Model derivative not implemented for {self.__class__.__name__}')
+
+    def mock_observation(self, par, kin=None, x=None, y=None, sb=None, binid=None,
+                         vel_ivar=None, vel_covar=None, vel_mask=None, sig_ivar=None,
+                         sig_covar=None, sig_mask=None, sig_corr=None, beam=None, is_fft=False,
+                         cnvfftw=None, ignore_beam=False, add_err=False, positive_definite=False,
+                         rng=None):
+        r"""
+        Construct a mock observation.
+
+        The mock data can be defined in one of two ways:
+
+            #. If a :class:`~nirvana.data.kinematics.Kinematics` object is
+               provided using the ``kin`` keyword, all other keyword arguments
+               are ignored and the mock data are meant to explicitly mimic the
+               real observations.
+
+            #. Otherwise, most of the other keywords are used to instantiate a
+               mock :class:`~nirvana.data.kinematics.Kinematics` object.  Just
+               like when instantiating a
+               :class:`~nirvana.data.kinematics.Kinematics` object, the provided
+               data arrays *must* be 2D and all have the same shape.
+
+        The mock observation is constructed by sampling the model exactly as
+        done when fitting real observations.  If errors are provided and
+        ``add_err`` is True, Gaussian error is added to the model values.
+
+        .. warning::
+
+            - Unlike :func:`model`, this method does *not* use any pre-existing
+              attributes in place of keyword arguments that are not directly
+              provided.  For example, if ``beam`` is None on input,
+              :attr:`beam_fft` will *not* be used even if available.  Instead,
+              this method calls :func:`reinit` to reinitialize the object such
+              that the mock observation is built from the provided arguments
+              only.
+
+            - Covariance matrices are expected to be positive-definite on input!
+
+            - When adding error, masked elements are ignored (i.e., no error is
+              added to them).
+
+        Args:
+            par (array-like):
+                The list of model parameters to use. Length must be :attr:`np`.
+            kin (:class:`~nirvana.data.kinematics.Kinematics`, optional):
+                Object with the kinematic data to mimic.  If None, must provide
+                at least ``x``, ``y``, and ``vel_ivar``.
+            x (`numpy.ndarray`_, optional):
+                The 2D x-coordinates at which to evaluate the model. Ignored if
+                ``kin`` is provided.
+            y (`numpy.ndarray`_, optional):
+                The 2D y-coordinates at which to evaluate the model.  Shape must
+                match ``x``.  Ignored if ``kin`` is provided.  
+            sb (`numpy.ndarray`_, optional):
+                2D array with the (nominally unbinned) surface brightness of the
+                object. This is used to weight the convolution of the kinematic
+                fields according to the luminosity distribution of the object.
+                Must have the same shape as ``x``. If None, the convolution is
+                unweighted.  If a convolution is not performed (``beam`` is None
+                or ``ignore_beam`` is True) or if ``kin`` is provided, this
+                array is ignored.
+            binid (`numpy.ndarray`_, optional):
+                2D integer array associating each measurement with a unique bin
+                ID number. Measurements not associated with any bin should have
+                a value of -1 in this array. If None, all unmasked measurements
+                (see ``vel_mask`` and ``sig_mask``) are considered unique.
+                Shape must match ``x``.  Ignored if ``kin`` is provided.
+            vel_ivar (`numpy.ndarray`_, `numpy.ma.MaskedArray`_, optional):
+                2D array with the inverse variance of the velocity measurements.
+                If both this and ``vel_covar`` are None, no errors are added to
+                the model data.  Shape must match ``x``, and all array elements
+                with the same bin ID should have the same value.  If both
+                ``vel_ivar`` and ``vel_covar`` are provided, the latter takes
+                precedence.  Ignored if ``kin`` is provided.
+            vel_covar (`numpy.ndarray`_, `scipy.sparse.csr_matrix`_):
+                Covariance matrix for the velocity measurements.  If both this
+                and ``vel_ivar`` are None, no errors are added to the model
+                data.  The array must be square, where the length along one side
+                matches the number elements in ``x``.  If both ``vel_ivar`` and
+                ``vel_covar`` are provided, the latter takes precedence.
+                Ignored if ``kin`` is provided.
+            vel_mask (`numpy.ndarray`_, optional):
+                2D boolean array with a bad-pixel mask for the velocity
+                measurements (a mask value of True is ignored).  If None, all
+                velocity values are considered valid.  Shape must match ``x``.
+                If ``vel_ivar`` is a `numpy.ma.MaskedArray`_, this mask is
+                *combined* with ``vel_ivar.mask``.  Ignored if ``kin`` is
+                provided.
+            sig_ivar (`numpy.ndarray`_, `numpy.ma.MaskedArray`_, optional):
+                2D array with the inverse variance of the velocity dispersion
+                measurements.  If ``kin`` is provided or no velocity dispersion
+                parameterization is defined (i.e., :attr:`dc` is None), this is
+                ignored.  If both this and ``sig_covar`` are None, no errors are
+                added to the model data.  Shape must match ``x``, and all array
+                elements with the same bin ID should have the same value.  If
+                both ``sig_ivar`` and ``sig_covar`` are provided, the latter
+                takes precedence.
+            sig_covar (`numpy.ndarray`_, `scipy.sparse.csr_matrix`_):
+                Covariance matrix for the velocity dispersion measurements.  If
+                ``kin`` is provided or no velocity dispersion parameterization
+                is defined (i.e., :attr:`dc` is None), this is ignored.  If both
+                this and ``sig_ivar`` are None, no errors are added to the model
+                data.  The array must be square, where the length along one side
+                matches the number elements in ``x``.  If both ``sig_ivar`` and
+                ``sig_covar`` are provided, the latter takes precedence.
+            sig_mask (`numpy.ndarray`_, optional):
+                2D boolean array with a bad-pixel mask for the velocity
+                dispersion measurements (a mask value of True is ignored).  If
+                ``kin`` is provided or no velocity dispersion parameterization
+                is defined (i.e., :attr:`dc` is None), this is ignored.  If
+                None, all velocity dispersion values are considered valid.
+                Shape must match ``x``.  If ``sig_ivar`` is a
+                `numpy.ma.MaskedArray`_, this mask is *combined* with
+                ``sig_ivar.mask``.
+            sig_corr (`numpy.ndarray`_, optional):
+                A quadrature correction for the velocity dispersion
+                measurements. If None, velocity dispersions are assumed to be
+                the *astrophysical* Doppler broadening of the kinematic tracer.
+                If provided, the observed velocity dispersion used to construct
+                the mock :class:`~nirvana.data.kinematics.Kinematics` object is:
+
+                .. math::
+                    \sigma_{\rm obs}^2 = \sigma^2 + \sigma_{\rm corr}^2,
+
+                where the model is used to calculate :math:`\sigma`.
+            beam (`numpy.ndarray`_, optional):
+                The 2D rendering of the beam-smearing kernel, or its Fast
+                Fourier Transform (FFT).  If ``kin`` is provided, this is
+                ignored.  If not provided, no beam convolution is performed when
+                constructing the mock observations.
+            is_fft (:obj:`bool`, optional):
+                The provided ``beam`` object is already the FFT of the
+                beam-smearing kernel.  Ignored if ``kin`` is provided or
+                ``beam`` is not provided.
+            cnvfftw (:class:`~nirvana.models.beam.ConvolveFFTW`, optional):
+                An object that expedites the convolutions using
+                FFTW/pyFFTW. If None, the convolution is done using numpy
+                FFT routines.
+            ignore_beam (:obj:`bool`, optional):
+                Regardless of the availability of the beam profile, ignore it
+                and do not include it in the returned object.
+            add_err (:obj:`bool`, optional):
+                If provided by either ``kin`` or the method keyword arguments,
+                use the error distributions to add error to the mock model data.
+                Nominally, error should be added to mock observations, but it's
+                more efficient to create a noiseless dataset and then create
+                many noise realizations (see
+                :func:`~nirvana.data.kinematics.Kinematics.deviate`).  This
+                keyword only results in a single noise realization.
+            rng (`numpy.random.Generator`, optional):
+                Generator object to use.  If None, a new Generator is
+                instantiated; see :func:`~nirvana.data.util.gaussian_deviates`.
+
+        Returns:
+            :class:`~nirvana.data.kinematics.Kinematics`:  Object providing the
+            mock observations.  This object can be fit, e.g., with
+            :func:`lsq_fit`, as would be done with real observations.
+        """
+
+        # Get the input errors.  This is done first for the checks that follow.
+        if kin is None:
+            _vel_ivar = vel_ivar
+            _vel_covar = vel_covar
+            _sig_ivar = sig_ivar
+            _sig_covar = sig_covar
+        else:
+            _vel_ivar = None if kin.vel_ivar is None \
+                        else kin.remap('vel_ivar', masked=False, fill_value=0.)
+            _vel_covar = None if kin.vel_covar is None else kin.remap_covar('vel_covar')
+            _sig_ivar = None if self.dc is None or kin.sig_ivar is None \
+                        else kin.remap('sig_ivar', masked=False, fill_value=0.)
+            _sig_covar = None if self.dc is None or kin.sig_covar is None \
+                            else kin.remap_covar('sig_covar')
+
+        if add_err:
+            # Check: Dispersion model not defined but error and mask provided
+            if self.dc is None and any([s is not None for s in [_sig_ivar, _sig_covar, _sig_mask]]):
+                warnings.warn('AxisymmetricDisk instance does not include dispersion profile '
+                                'model.  Ignoring provided dispersion errors and mask.')
+            # Check: Dispersion model available and mismatch between availability of errors
+            if self.dc is not None and (_vel_ivar is not None and _sig_ivar is None \
+                                        or _vel_ivar is None and _sig_ivar is not None \
+                                        or _vel_covar is not None and _sig_covar is None \
+                                        or _vel_covar is None and _sig_covar is not None):
+                raise ValueError('When adding error, must add error to both vel and sigma.')
+
+        # Instantiate the mock Kinematics object
+        if kin is None:
+            # Revert the fft to get the spatial representation of the beam profile
+            _beam = None if beam is None or ignore_beam \
+                        else (np.fft.fftshift(np.fft.ifftn(beam).real) if is_fft else beam)
+
+            vel = np.zeros(x.shape, dtype=float)
+            sig = None if self.dc is None else np.zeros(x.shape, dtype=float)
+            _kin = Kinematics(vel, vel_ivar=_vel_ivar, vel_mask=vel_mask, vel_covar=_vel_covar,
+                              x=x, y=y, sb=sb, sig=sig, sig_ivar=_sig_ivar, sig_mask=sig_mask,
+                              sig_covar=_sig_covar, sig_corr=sig_corr, psf=_beam, binid=binid,
+                              grid_x=x, grid_y=y, grid_sb=sb, positive_definite=positive_definite)
+        else:
+            _kin = kin.copy()
+
+        # Reinitialize
+        self.reinit()
+
+        # Initialize the fit parameters
+        self._init_par(par, None)
+
+        # Initialize the model
+        #                                                                            is_fft
+        self._init_model(par, _kin.grid_x, _kin.grid_y, _kin.grid_sb, _kin.beam_fft, True, cnvfftw,
+        #                ignore_beam
+                         False)
+
+        # Initialize the data
+        #                     scat, posdef, ignore_covar
+        self._init_data(_kin, None, True, True)
+
+        # Generate and bin the model data.  NOTE: Call above to _init_data sets
+        # _kin to self.kin, which is used by _binned_model...
+        _kin.vel, _sig = self._binned_model(par)
+        # If available, include the dispersion correction
+        if _kin.sig_corr is not None:
+            _sig = np.sqrt(_sig**2 + _kin.sig_corr**2)
+
+        # Set whether or not to add Gaussian noise
+        if not add_err or _vel_ivar is None and _vel_covar is None:
+            _kin.update_sigma(sig=_sig)
+            return _kin
+
+        # Get the deviates
+        sigma_method = 'ignore' if self.dc is None else 'draw' 
+        vgpm, dv, sgpm, ds = _kin.deviate(sigma=sigma_method, rng=rng)
+        # Add the velocity error
+        _kin.vel[vgpm] += dv
+        # Add the dispersion error and update the dispersion values
+        if self.dc is not None:
+            _sig[sgpm] += ds
+            _kin.update_sigma(sig=_sig)
+
+        return _kin
+
+    def fisher_matrix(self, par, kin, fix=None, sb_wgt=False, scatter=None,
+                      assume_posdef_covar=False, ignore_covar=True, cnvfftw=None,
+                      inverse=False):
+        r"""
+        Construct the Fisher Information Matrix (FIM) at a specific position in
+        parameter space for a set of observational constraints.
+
+        The FIM is calculated using the derivatives of the fit metric with
+        respect to the model parameters (the Jacobian), just as done during the
+        least-squares minimization.  The shape of the Jacobian is :math:`(N,M)`,
+        where :math:`N` is the number of data points and :math:`M` is the number
+        of model parameters.  The FIM, :math:`\mathbf{I}(\theta)`, is the
+        :math:`(M,M)` matrix defined as:
+
+        .. math::
+
+            \mathbf{I}(\theta) = \mathbf{J}^T \mathbf{J}
+
+        Importantly, the Jacobian and the FIM are both *independent of the
+        measurements*, but not independent of the statistical uncertainties in
+        those measurements.
+
+        .. warning::
+
+            Currently, this class *does not construct a model of the
+            surface-brightness distribution*.  Instead, any weighting of the
+            model during convolution with the beam profile uses the as-observed
+            surface-brightness distribution, instead of a model of the intrinsic
+            surface brightness distribution.  See ``sb_wgt``.
+
+        Args:
+            par (array-like):
+                The list of model parameters at which to calculate the FIM.
+                I.e., the FIM is dependent on the position in parameter space.
+                Length must be :attr:`np`.
+            kin (:class:`~nirvana.data.kinematics.Kinematics`):
+                Object with the kinematic data.  This provides the measurement
+                uncertainties needed for the construction of the FIM, and it
+                also provides the grid on which to compute the model, the
+                surface-brightness weighting, the beam-smearing kernel, and the
+                binning function.
+            fix (`numpy.ndarray`_, optional):
+                A boolean array selecting the parameters that are fixed.  These
+                parameters are excluded from the FIM.
+            sb_wgt (:obj:`bool`, optional):
+                Flag to use the surface-brightness data provided by ``kin`` to
+                weight the model when applying the beam-smearing.  **See the
+                warning above**.
+            scatter (:obj:`float`, array-like, optional):
+                Introduce a fixed intrinsic-scatter term into the model. The 
+                scatter is added in quadrature to all measurement errors in the
+                calculation of the merit function. If no errors are available,
+                this has the effect of renormalizing the unweighted merit
+                function by 1/scatter.  Can be None, which means no intrinsic
+                scatter is added.  If both velocity and velocity dispersion are
+                being fit, this can be a single number applied to both datasets
+                or a 2-element vector that provides different intrinsic scatter
+                measurements for each kinematic moment (ordered velocity then
+                velocity dispersion).
+            assume_posdef_covar (:obj:`bool`, optional):
+                If the :class:`~nirvana.data.kinematics.Kinematics` include
+                covariance matrices, this forces the code to proceed assuming
+                the matrices are positive definite.
+            ignore_covar (:obj:`bool`, optional):
+                If the :class:`~nirvana.data.kinematics.Kinematics` include
+                covariance matrices, ignore them and just use the inverse
+                variance.
+            cnvfftw (:class:`~nirvana.models.beam.ConvolveFFTW`, optional):
+                An object that expedites the convolutions using FFTW/pyFFTW.  If
+                provided, the shape *must* match ``kin.spatial_shape``.  If
+                None, a new :class:`~nirvana.models.beam.ConvolveFFTW` instance
+                is constructed to perform the convolutions.  If the class cannot
+                be constructed because the user doesn't have pyfftw installed,
+                then the convolutions fall back to numpy routines.
+            inverse (:obj:`bool`, optional):
+                Return the inverse of the FIM, which is equivalent to the
+                covariance matrix in the model parameters.
+
+        Returns:
+            `numpy.ndarray`_: The :math:`(M,M)` Fisher Information Matrix, or
+            its inverse, at the selected position in parameter space.
+        """
+        self._init_par(par, fix)
+        self._init_model(par, kin.grid_x, kin.grid_y, kin.grid_sb if sb_wgt else None,
+                         kin.beam_fft, True, cnvfftw, False)
+        self._init_data(kin, scatter, assume_posdef_covar, ignore_covar)
+#        self._fit_prep(kin, par, fix, scatter, sb_wgt, assume_posdef_covar, ignore_covar,
+#                       cnvfftw)
+        jac = self._get_jac()(self.par[self.free])
+        return cov_err(jac) if inverse else np.dot(jac.T,jac)
+
+    # This slew of "private" functions consolidate the velocity residual and
+    # chi-square calculations
+    def _v_resid(self, vel):
+        return self.kin.vel[self.vel_gpm] - vel[self.vel_gpm]
+    def _deriv_v_resid(self, dvel):
+        return -dvel[np.ix_(self.vel_gpm, self.free)]
+    def _v_chisqr(self, vel):
+        return self._v_resid(vel) / self._v_err[self.vel_gpm]
+    def _deriv_v_chisqr(self, dvel):
+        return self._deriv_v_resid(dvel) / self._v_err[self.vel_gpm, None]
+    def _v_chisqr_covar(self, vel):
+        return np.dot(self._v_resid(vel), self._v_ucov)
+    def _deriv_v_chisqr_covar(self, dvel):
+        return np.dot(self._deriv_v_resid(dvel).T, self._v_ucov).T
+
+    # This slew of "private" functions consolidate the velocity dispersion
+    # residual and chi-square calculations
+    def _s_resid(self, sig):
+        return self.kin.sig_phys2[self.sig_gpm] - sig[self.sig_gpm]**2
+    def _deriv_s_resid(self, sig, dsig):
+        return -2 * sig[self.sig_gpm,None] * dsig[np.ix_(self.sig_gpm, self.free)]
+    def _s_chisqr(self, sig):
+        return self._s_resid(sig) / self._s_err[self.sig_gpm]
+    def _deriv_s_chisqr(self, sig, dsig):
+        return self._deriv_s_resid(sig, dsig) / self._s_err[self.sig_gpm, None]
+    def _s_chisqr_covar(self, sig):
+        return np.dot(self._s_resid(sig), self._s_ucov)
+    def _deriv_s_chisqr_covar(self, sig, dsig):
+        return np.dot(self._deriv_s_resid(sig, dsig).T, self._s_ucov).T
+
+    def _binned_model(self, par):
+        """
+        Compute the binned model data.
+
+        Args:
+            par (`numpy.ndarray`_, optional):
+                The list of parameters to use. Length should be either
+                :attr:`np` or :attr:`nfree`. If the latter, the values of the
+                fixed parameters in :attr:`par` are used.
+
+        Returns:
+
+            :obj:`tuple`: Model velocity and velocity dispersion data.  The
+            latter is None if the model has no dispersion parameterization.
+        """
+        self._set_par(par)
+        if self.dc is None:
+            vel = self.model()
+            sig = None
+        else:
+            vel, sig = self.model()
+        return self.kin.bin_moments(self.sb, vel, sig)[1:]
+
+#       NOTE: LEAVE THIS OLD CODE HERE, in case we want to test the difference
+#       between the new and old approach.
+#        # TODO: This binning isn't exactly right...  Need to bin velocity and
+#        # velocity dispersion in the same way that we do the beam-smearing.
+#        # I.e., the binned velocity is sum_i w_i v_i / sum_i w_i, where w_i is
+#        # the luminosity weighting.  And the binned velocity dispersion should
+#        # be sqrt(sum_i w_i (v_i^2 + s_i^2) / sum_i w_i - bin_v^2)
+#        return (self.kin.bin(self.model()), None) if self.dc is None \
+#                        else map(lambda x : self.kin.bin(x), self.model())
+
+    def _deriv_binned_model(self, par):
+        """
+        Compute the binned model data and its derivatives.
+
+        Args:
+            par (`numpy.ndarray`_, optional):
+                The list of parameters to use. Length should be either
+                :attr:`np` or :attr:`nfree`. If the latter, the values of the
+                fixed parameters in :attr:`par` are used.
+
+        Returns:
+            :obj:`tuple`: Model velocity data, velocity dispersion data,
+            velocity derivative, and velocity dispersion derivative.  The
+            velocity dispersion components (2nd and 4th objects) are None if the
+            model has no dispersion parameterization.
+        """
+        self._set_par(par)
+        if self.dc is None:
+            vel, dvel = self.deriv_model()
+            sig, dsig = None, None
+        else:
+            vel, sig, dvel, dsig = self.deriv_model()
+        _, vel, sig, _, dvel, dsig \
+                = self.kin.deriv_bin_moments(self.sb, vel, sig, None, dvel, dsig)
+        return vel, sig, dvel, dsig
+
+#       NOTE: LEAVE THIS OLD CODE HERE, in case we want to test the difference
+#       between the new and old approach.
+#        if self.dc is None:
+#            vel, dvel = self.kin.deriv_bin(*self.deriv_model())
+#            return vel, None, dvel, None
+#        vel, sig, dvel, dsig = self.deriv_model()
+#        vel, dvel = self.kin.deriv_bin(vel, dvel)
+#        sig, dsig = self.kin.deriv_bin(sig, dsig)
+#        return vel, sig, dvel, dsig
+
+    def _resid(self, par, sep=False):
+        """
+        Calculate the residuals between the data and the current model.
+
+        Args:
+            par (`numpy.ndarray`_, optional):
+                The list of parameters to use. Length should be either
+                :attr:`np` or :attr:`nfree`. If the latter, the values of the
+                fixed parameters in :attr:`par` are used.
+            sep (:obj:`bool`, optional):
+                Return separate vectors for the velocity and velocity
+                dispersion residuals, instead of appending them.
+
+        Returns:
+            :obj:`tuple`, `numpy.ndarray`_: Difference between the data and the
+            model for all measurements, either returned as a single vector for
+            all data or as separate vectors for the velocity and velocity
+            dispersion data (based on ``sep``).
+        """
+        vel, sig = self._binned_model(par)
+        vfom = self._v_resid(vel)
+        sfom = numpy.array([]) if self.dc is None else self._s_resid(sig)
+        return (vfom, sfom) if sep else np.append(vfom, sfom)
+
+    def _deriv_resid(self, par, sep=False):
+        """
+        Calculate the derivative of the fit residuals w.r.t. all the *free*
+        model parameters.
+
+        Args:
+            par (`numpy.ndarray`_, optional):
+                The list of parameters to use. Length should be either
+                :attr:`np` or :attr:`nfree`. If the latter, the values of the
+                fixed parameters in :attr:`par` are used.
+            sep (:obj:`bool`, optional):
+                Return separate vectors for the velocity and velocity dispersion
+                residual derivatives, instead of appending them.
+
+        Returns:
+            :obj:`tuple`, `numpy.ndarray`_: Derivatives in the difference
+            between the data and the model for all measurements, either returned
+            as a single array for all data or as separate arrays for the
+            velocity and velocity dispersion data (based on ``sep``).
+        """
+        vel, sig, dvel, dsig = self._deriv_binned_model(par)
+        if self.dc is None:
+            return (self._deriv_v_resid(dvel), numpy.array([])) \
+                        if sep else self._deriv_v_resid(dvel)
+        resid = (self._deriv_v_resid(vel), self._deriv_s_resid(sig, dsig))
+        return resid if sep else np.vstack(resid)
+
+    def _chisqr(self, par, sep=False):
+        """
+        Calculate the error-normalized residual (close to the signed
+        chi-square metric) between the data and the current model.
+
+        Args:
+            par (`numpy.ndarray`_, optional):
+                The list of parameters to use. Length should be either
+                :attr:`np` or :attr:`nfree`. If the latter, the values of the
+                fixed parameters in :attr:`par` are used.
+            sep (:obj:`bool`, optional):
+                Return separate vectors for the velocity and velocity
+                dispersion residuals, instead of appending them.
+
+        Returns:
+            :obj:`tuple`, `numpy.ndarray`_: Difference between the data and the
+            model for all measurements, normalized by their errors, either
+            returned as a single vector for all data or as separate vectors for
+            the velocity and velocity dispersion data (based on ``sep``).
+        """
+        vel, sig = self._binned_model(par)
+        if self.has_covar:
+            vfom = self._v_chisqr_covar(vel)
+            sfom = np.array([]) if self.dc is None else self._s_chisqr_covar(sig)
+        else:
+            vfom = self._v_chisqr(vel)
+            sfom = np.array([]) if self.dc is None else self._s_chisqr(sig)
+        return (vfom, sfom) if sep else np.append(vfom, sfom)
+
+    def _deriv_chisqr(self, par, sep=False):
+        """
+        Calculate the derivatives of the error-normalized residuals (close to
+        the signed chi-square metric) w.r.t. the *free* model parameters.
+
+        Args:
+            par (`numpy.ndarray`_, optional):
+                The list of parameters to use. Length should be either
+                :attr:`np` or :attr:`nfree`. If the latter, the values of the
+                fixed parameters in :attr:`par` are used.
+            sep (:obj:`bool`, optional):
+                Return separate vectors for the velocity and velocity
+                dispersion residuals, instead of appending them.
+
+        Returns:
+            :obj:`tuple`, `numpy.ndarray`_: Derivatives of the error-normalized
+            difference between the data and the model for all measurements
+            w.r.t. the *free* model parameters, either returned as a single
+            array for all data or as separate arrays for the velocity and
+            velocity dispersion data (based on ``sep``).
+        """
+        vel, sig, dvel, dsig = self._deriv_binned_model(par)
+        vf = self._deriv_v_chisqr_covar if self.has_covar else self._deriv_v_chisqr
+        if self.dc is None:
+            return (vf(dvel), numpy.array([])) if sep else vf(dvel)
+
+        sf = self._deriv_s_chisqr_covar if self.has_covar else self._deriv_s_chisqr
+        dchisqr = (vf(dvel), sf(sig, dsig))
+        if not np.all(np.isfinite(dchisqr[0])) or not np.all(np.isfinite(dchisqr[1])):
+            raise ValueError('Error in derivative computation.')
+        return dchisqr if sep else np.vstack(dchisqr)
+
+    def _get_fom(self):
+        """
+        Return the figure-of-merit function to use given the availability of
+        errors.
+        """
+        return self._chisqr if self.has_err or self.has_covar else self._resid
+
+    def _get_jac(self):
+        """
+        Return the Jacobian function to use given the availability of errors.
+        """
+        return self._deriv_chisqr if self.has_err or self.has_covar else self._deriv_resid
+
+    # TODO: Include an argument here that allows the PSF convolution to be
+    # toggled, regardless of whether or not the `kin` object has the beam
+    # defined.
+    def lsq_fit(self, kin, sb_wgt=False, p0=None, fix=None, lb=None, ub=None, scatter=None,
+                verbose=0, assume_posdef_covar=False, ignore_covar=True, cnvfftw=None,
+                analytic_jac=True, maxiter=5):
+        """
+        Use `scipy.optimize.least_squares`_ to fit the model to the provided
+        kinematics.
+
+        It is possible that the call to `scipy.optimize.least_squares`_ returns
+        fitted parameters that are identical to the input guess parameters.
+        Because of this, the fit can be repeated multiple times (see
+        ``maxiter``), where each attempt slightly peturbs the parameters.
+
+        Once complete, the best-fitting parameters are saved to :attr:`par`
+        and the parameter errors (estimated by the parameter covariance
+        matrix constructed as a by-product of the least-squares fit) are
+        saved to :attr:`par_err`.
+
+        .. warning::
+
+            Currently, this class *does not construct a model of the
+            surface-brightness distribution*.  Instead, any weighting of the
+            model during convolution with the beam profile uses the as-observed
+            surface-brightness distribution, instead of a model of the intrinsic
+            surface brightness distribution.  See ``sb_wgt``.
+
+        Args:
+            kin (:class:`~nirvana.data.kinematics.Kinematics`):
+                Object with the kinematic data to fit.
+            sb_wgt (:obj:`bool`, optional):
+                Flag to use the surface-brightness data provided by ``kin`` to
+                weight the model when applying the beam-smearing.  **See the
+                warning above**.
+            p0 (`numpy.ndarray`_, optional):
+                The initial parameters for the model. Length must be
+                :attr:`np`.
+            fix (`numpy.ndarray`_, optional):
+                A boolean array selecting the parameters that should be fixed
+                during the model fit.
+            lb (`numpy.ndarray`_, optional):
+                The lower bounds for the parameters. If None, the defaults
+                are used (see :func:`par_bounds`). The length of the vector
+                must match the total number of parameters, even if some of
+                the parameters are fixed.
+            ub (`numpy.ndarray`_, optional):
+                The upper bounds for the parameters. If None, the defaults
+                are used (see :func:`par_bounds`). The length of the vector
+                must match the total number of parameters, even if some of
+                the parameters are fixed.
+            scatter (:obj:`float`, array-like, optional):
+                Introduce a fixed intrinsic-scatter term into the model. The 
+                scatter is added in quadrature to all measurement errors in the
+                calculation of the merit function. If no errors are available,
+                this has the effect of renormalizing the unweighted merit
+                function by 1/scatter.  Can be None, which means no intrinsic
+                scatter is added.  If both velocity and velocity dispersion are
+                being fit, this can be a single number applied to both datasets
+                or a 2-element vector that provides different intrinsic scatter
+                measurements for each kinematic moment (ordered velocity then
+                velocity dispersion).
+            verbose (:obj:`int`, optional):
+                Verbosity level to pass to `scipy.optimize.least_squares`_.
+            assume_posdef_covar (:obj:`bool`, optional):
+                If the :class:`~nirvana.data.kinematics.Kinematics` includes
+                covariance matrices, this forces the code to proceed assuming
+                the matrices are positive definite.
+            ignore_covar (:obj:`bool`, optional):
+                If the :class:`~nirvana.data.kinematics.Kinematics` includes
+                covariance matrices, ignore them and just use the inverse
+                variance.
+            cnvfftw (:class:`~nirvana.models.beam.ConvolveFFTW`, optional):
+                An object that expedites the convolutions using FFTW/pyFFTW.  If
+                provided, the shape *must* match ``kin.spatial_shape``.  If
+                None, a new :class:`~nirvana.models.beam.ConvolveFFTW` instance
+                is constructed to perform the convolutions.  If the class cannot
+                be constructed because the user doesn't have pyfftw installed,
+                then the convolutions fall back to the numpy routines.
+            analytic_jac (:obj:`bool`, optional):
+                Use the analytic calculation of the Jacobian matrix during the
+                fit optimization.  If False, the Jacobian is calculated using
+                finite-differencing methods provided by
+                `scipy.optimize.least_squares`_.
+            maxiter (:obj:`int`, optional):
+                The call to `scipy.optimize.least_squares`_ is repeated when it
+                returns best-fit parameters that are *identical* to the input
+                parameters.  This parameter sets the maximum number of times the
+                fit will be repeated.  Set this to 1 to ignore these occurences;
+                ``maxiter`` cannot be None.
+        """
+        if maxiter is None:
+            raise ValueError('Maximum number of iterations cannot be None.')
+
+        # Prepare to fit the data.
+        self._init_par(p0, fix)
+        self._init_model(None, kin.grid_x, kin.grid_y, kin.grid_sb if sb_wgt else None,
+                         kin.beam_fft, True, cnvfftw, False)
+        self._init_data(kin, scatter, assume_posdef_covar, ignore_covar)
+#        self._fit_prep(kin, p0, fix, scatter, sb_wgt, assume_posdef_covar, ignore_covar,
+#                       cnvfftw)
+        
+        # Get the method used to generate the figure-of-merit and the Jacobian
+        # matrix.
+        fom = self._get_fom()
+        # If the analytic Jacobian matrix is not used, the derivative of the
+        # merit function wrt each parameter is determined by a 1% change in each
+        # parameter.
+        jac_kwargs = {'jac': self._get_jac()} if analytic_jac \
+                        else {'diff_step': np.full(self.np, 0.01, dtype=float)[self.free]}
+
+        # Parameter boundaries
+        _lb, _ub = self.par_bounds()
+        if lb is None:
+            lb = _lb
+        if ub is None:
+            ub = _ub
+        if len(lb) != self.np or len(ub) != self.np:
+            raise ValueError('Length of one or both of the bound vectors is incorrect.')
+
+        # Set the random number generator with a fixed seed so that the result
+        # is deterministic.
+        rng = np.random.default_rng(seed=909)
+        _p0 = self.par[self.free]
+        p = _p0.copy()
+        pe = None
+        niter = 0
+        while niter < maxiter:
+            # Run the optimization
+            result = optimize.least_squares(fom, p, # method='lm', #xtol=None,
+                                            x_scale='jac', method='trf', xtol=1e-12,
+                                            bounds=(lb[self.free], ub[self.free]), 
+                                            verbose=max(verbose,0), **jac_kwargs)
+            try:
+                pe = np.sqrt(np.diag(cov_err(result.jac)))
+            except:
+                warnings.warn('Unable to compute parameter errors from precision matrix.')
+                pe = None
+
+            # The fit should change the input parameters.
+            if np.all(np.absolute(p-result.x) > 1e-3):
+                break
+
+            # If it doesn't, something likely went wrong with the fit.  Perturb
+            # the input guesses a bit and retry.
+            p = _p0 + rng.normal(size=self.nfree)*(pe if pe is not None else 0.1*p0)
+            p = np.clip(p, lb[self.free], ub[self.free])
+            niter += 1
+
+        # TODO: Add something to the fit status/success flags that tests if
+        # niter == maxiter and/or if the input parameters are identical to the
+        # final best-fit prameters?  Note that the input parameters, p0, may not
+        # be identical to the output parameters because of the iterations mean
+        # that p != p0 !
+
+        # Save the fit status
+        self.fit_status = result.status
+        self.fit_success = result.success
+
+        # Save the best-fitting parameters
+        self._set_par(result.x)
+        if pe is None:
+            self.par_err = None
+        else:
+            self.par_err = np.zeros(self.np, dtype=float)
+            self.par_err[self.free] = pe
+
+        # Print the report
+        if verbose > -1:
+            self.report(fit_message=result.message)
+
+    def report(self, fit_message=None):
+        """
+        Report the current parameters of the model to the screen.
+
+        Args:
+            fit_message (:obj:`str`, optional):
+                The status message returned by the fit optimization.
+        """
+        pass
+

--- a/nirvana/scripts/manga_axisym.py
+++ b/nirvana/scripts/manga_axisym.py
@@ -108,7 +108,9 @@ def parse_args(options=None):
                              'region.')
     parser.add_argument('--screen', default=False, action='store_true',
                         help='Indicate that the script is being run behind a screen (used to set '
-                             'matplotlib backend).') 
+                             'matplotlib backend).')
+    parser.add_argument('--skip_plots', default=False, action='store_true',
+                        help='Skip the QA plots and just produce the main output file.')
 
     # TODO: Other options:
     #   - Fit with least-squares vs. dynesty
@@ -180,6 +182,13 @@ def main(args):
                                      select_coherent=args.coherent, fit_scatter=args.fit_scatter,
                                      verbose=args.verbose)
 
+    # Write the output file
+    data_file = os.path.join(args.odir, f'{oroot}.fits.gz')
+    axisym.axisym_fit_data(galmeta, kin, p0, disk, data_file, vel_mask, sig_mask)
+
+    if args.skip_plots:
+        return
+
     # Plot the final residuals
     dv_plot = os.path.join(args.odir, f'{oroot}-vdist.png')
     ds_plot = os.path.join(args.odir, f'{oroot}-sdist.png')
@@ -198,9 +207,5 @@ def main(args):
     # Create the final fit plot
     fit_plot = os.path.join(args.odir, f'{oroot}-fit.png')
     axisym.axisym_fit_plot(galmeta, kin, disk, fix=fix, ofile=fit_plot)
-
-    # Write the output file
-    data_file = os.path.join(args.odir, f'{oroot}.fits.gz')
-    axisym.axisym_fit_data(galmeta, kin, p0, disk, data_file, vel_mask, sig_mask)
 
 

--- a/nirvana/scripts/manga_axisym.py
+++ b/nirvana/scripts/manga_axisym.py
@@ -192,9 +192,8 @@ def main(args):
     # Plot the final residuals
     dv_plot = os.path.join(args.odir, f'{oroot}-vdist.png')
     ds_plot = os.path.join(args.odir, f'{oroot}-sdist.png')
-    axisym.disk_fit_resid_dist(kin, disk, disp=args.disp, ignore_covar=not args.covar,
-                               vel_mask=vel_mask, vel_plot=dv_plot, sig_mask=sig_mask,
-                               sig_plot=ds_plot) 
+    disk.reject(disp=args.disp, ignore_covar=not args.covar, vel_plot=dv_plot, sig_plot=ds_plot,
+                plots_only=True) 
 
     # Plot the fit asymmetry
     asym_plot = os.path.join(args.odir, f'{oroot}-asym.png')

--- a/nirvana/tests/test_asym.py
+++ b/nirvana/tests/test_asym.py
@@ -12,7 +12,6 @@ from nirvana.models import asymmetry
 from nirvana.models import axisym
 from nirvana.models import bisym
 from nirvana.models import oned
-from nirvana.data.util import select_major_axis, inverse
 from nirvana.data import manga
 from nirvana.tests.util import remote_data_file, requires_remote
 

--- a/nirvana/tests/test_axisym.py
+++ b/nirvana/tests/test_axisym.py
@@ -294,8 +294,11 @@ def test_disk_fit_derivative():
     #                 x0      y0      pa     inc    vsys   vinf   hv      sig0   hsig
     dp = numpy.array([0.0001, 0.0001, 0.001, 0.001, 0.001, 0.001, 0.0001, 0.001, 0.0001])
 
-    # Run the fit preparation
-    disk._fit_prep(kin, p0, None, None, True, True, True, None)
+    # Prepare
+    disk._init_par(p0, None)
+    disk._init_model(None, kin.grid_x, kin.grid_y, kin.grid_sb, kin.beam_fft, True, None, False)
+    disk._init_data(kin, None, True, True)
+#    disk._fit_prep(kin, p0, None, None, True, True, True, None)
     # Get the method used to generate the figure-of-merit and the jacobian
     fom = disk._get_fom()
     jac = disk._get_jac()

--- a/nirvana/tests/test_bisym.py
+++ b/nirvana/tests/test_bisym.py
@@ -55,24 +55,21 @@ def test_lsq_nopsf():
     kin = manga.MaNGAGasKinematics.from_plateifu(8078, 12703, cube_path=data_root,
                                                  maps_path=data_root, ignore_psf=True)
 
-    rc = HyperbolicTangent(lb=numpy.array([0., 1e-3]), ub=numpy.array([500., kin.max_radius()]))
-    # Set the disk velocity field
-    axisym_disk = AxisymmetricDisk(rc=rc)
-    # Fit it with a non-linear least-squares optimizer
-    axisym_disk.lsq_fit(kin, verbose=2)
-
-    embed()
-    exit()
+#    rc = HyperbolicTangent(lb=numpy.array([0., 1e-3]), ub=numpy.array([500., kin.max_radius()]))
+#    # Set the disk velocity field
+#    axisym_disk = AxisymmetricDisk(rc=rc)
+#    # Fit it with a non-linear least-squares optimizer
+#    axisym_disk.lsq_fit(kin, verbose=2)
 
     # Set the disk velocity field
     bisym_disk = BisymmetricDisk()
     # Fit it with a non-linear least-squares optimizer
     bisym_disk.lsq_fit(kin, verbose=2, analytic_jac=False)
 
-    assert numpy.all(numpy.absolute(disk.par[:2]) < 0.1), 'Center changed'
-    assert 165. < disk.par[2] < 167., 'PA changed'
-    assert 53. < disk.par[3] < 55., 'Inclination changed'
-    assert 243. < disk.par[5] < 245., 'Projected rotation changed'
+#    assert numpy.all(numpy.absolute(disk.par[:2]) < 0.1), 'Center changed'
+#    assert 165. < disk.par[2] < 167., 'PA changed'
+#    assert 53. < disk.par[3] < 55., 'Inclination changed'
+#    assert 243. < disk.par[5] < 245., 'Projected rotation changed'
 
 
 test_lsq_nopsf()

--- a/nirvana/tests/test_scripts.py
+++ b/nirvana/tests/test_scripts.py
@@ -1,0 +1,32 @@
+
+import os
+import shutil
+
+from IPython import embed
+
+from astropy.io import fits
+
+from nirvana.scripts import manga_axisym
+from nirvana.tests.util import remote_data_file, requires_remote
+
+@requires_remote
+def test_manga_axisym():
+    odir = remote_data_file('tests/8138')
+    if os.path.isdir(odir):
+        shutil.rmtree(odir)
+
+    args = manga_axisym.parse_args(['8138', '12704', '--root', remote_data_file(), '--odir', odir,
+                                    '-t', 'Gas', '--min_vel_snr', '5', '--min_sig_snr', '5',
+                                    '--max_vel_err', '100', '--max_sig_err', '100',
+                                    '--min_unmasked', '10', '--coherent', '--skip_plots'])
+    manga_axisym.main(args)
+
+    main_output_file = os.path.join(odir, 'nirvana-manga-axisym-8138-12704-Gas.fits.gz')
+    assert os.path.isfile(main_output_file), 'Output file not created.'
+
+    with fits.open(main_output_file) as hdu:
+        assert len(hdu) == 24, 'Data model changed'
+        assert hdu['FITMETA'].data['RCHI2'] < 1.1, 'Fit dramatically changed'
+
+    shutil.rmtree(odir)
+


### PR DESCRIPTION
In this PR:

 - Consolidate common functionality between `AxisymmetricDisk` and
   `BisymmetricDisk` into a common parent class called `ThinDisk`.
 - Construct radial profiles of deprojected kinematics
 - Save radial profiles along the major and minor axes of both the tangential
   speed and the velocity dispersion
 - Fit rejection iterations moved to common parent class, `ThinDisk`.
