### PR TITLE
Simultaneous fits to multiple tracers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
    closer to the effects of binning the spectra and then fitting the kinematics.
  - Added method to compute Fisher Information Matrix for axisymmetric fits.
  - Added new asymmetry map calculations
+ - Added asymmetric drift fitting
 
 
 0.1.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,8 +51,8 @@
  - Add a plot that shows the different masking steps
  - For MaNGA:
     - Improve download functionality
-    - Change to using redshift in DAPall file, instead of DRPall file to include
-      corrections made in the former (see the mangadap redshift fix file)
+    - Change to using redshift in DAPall file, instead of DRPall file, so as to
+      include known corrections (see the mangadap redshift fix file)
     - Include targeting and data-quality bits and row indices in DRPall/DAPall
       files in the main Kinematics classes
     - Enable consolidated output databases for both independent fits and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,8 +39,25 @@
  - Save radial profiles along the major and minor axes of both the tangential
    speed and the velocity dispersion
  - Fit rejection iterations moved to common parent class, `ThinDisk`.
- - Added simultaneous fitting of gas and stellar kinematics, particularly useful
-   for measuring asymmetric drift
+ - Added `MultiTracerDisk` class that enables one to simultaneously fit multiple
+   kinematic tracers of the same disk.  This is currently only used for
+   simultaneous fitting of gas and stellar kinematics, particularly useful for
+   measuring asymmetric drift
+ - Improve asymmetry measures and plots
+ - Construct radial profiles with and without beam-smearing "corrections"
+ - Change main axisymmetric fit diagnostic plots to include effects of
+   beam-smearing on velocity and velocity dispersion fields (instead of showing
+   the intrinsic fields)
+ - Add a plot that shows the different masking steps
+ - For MaNGA:
+    - Improve download functionality
+    - Change to using redshift in DAPall file, instead of DRPall file to include
+      corrections made in the former (see the mangadap redshift fix file)
+    - Include targeting and data-quality bits and row indices in DRPall/DAPall
+      files in the main Kinematics classes
+    - Enable consolidated output databases for both independent fits and
+      combined (stars+gas) fits
+    - Fix download_test_data.py script to download public data from DR17
 
 0.1.0
 -----

--- a/bin/nirvana_manga_asymdrift
+++ b/bin/nirvana_manga_asymdrift
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+from nirvana.scripts import manga_asymdrift
+
+if __name__ == '__main__':
+    manga_asymdrift.main(manga_asymdrift.parse_args())
+

--- a/download_test_data.py
+++ b/download_test_data.py
@@ -1,104 +1,120 @@
 
+from pathlib import Path
 import os
 import warnings
 import tqdm
 import requests
 import netrc
 
+from nirvana.util.download import download_file
 from nirvana.tests.util import remote_data_file, remote_drp_test_files, remote_drp_test_images
 from nirvana.tests.util import remote_dap_test_files
 from nirvana.tests.util import drp_test_version, dap_test_version, dap_test_daptype
 
-# TODO: Change this to use the (now) public data
-try:
-    NETRC = netrc.netrc()
-except Exception as e:
-    raise FileNotFoundError('Could not load ~/.netrc file.') from e
+## TODO: Change this to use the (now) public data
+#try:
+#    NETRC = netrc.netrc()
+#except Exception as e:
+#    raise FileNotFoundError('Could not load ~/.netrc file.') from e
+#
+#HOST = 'data.sdss.org'
+#if HOST not in NETRC.hosts:
+#    raise ValueError('Host data.sdss.org is not defined in your ~/.netrc file.')
 
-HOST = 'data.sdss.org'
-if HOST not in NETRC.hosts:
-    raise ValueError('Host data.sdss.org is not defined in your ~/.netrc file.')
 
-
-def download_file(remote_root, usr, passwd, local_root, file, overwrite=True):
-    """
-    Thanks to 
-    https://stackoverflow.com/questions/37573483/progress-bar-while-download-file-over-http-with-requests/37573701
-    """
-    #Beware of how this is joined!
-    url = '{0}{1}'.format(remote_root, file)
-    ofile = os.path.join(local_root, file)
-
-    if os.path.isfile(ofile):
-        if overwrite:
-            warnings.warn('Overwriting existing file: {0}'.format(ofile))
-            os.remove(ofile)
-        else:
-            raise FileExistsError('File already exists.  To overwrite, set overwrite=True.')
-
-    print('Downloading: {0}'.format(url))
-    # Streaming, so we can iterate over the response.
-    r = requests.get(url, stream=True, auth=(usr, passwd))
-    # Total size in bytes.
-    total_size = int(r.headers.get('content-length', 0))
-    block_size = 1024 #1 Kibibyte
-    t = tqdm.tqdm(total=total_size, unit='iB', unit_scale=True)
-    with open(ofile, 'wb') as f:
-        for data in r.iter_content(block_size):
-            t.update(len(data))
-            f.write(data)
-    t.close()
-    if total_size != 0 and t.n != total_size:
-        raise ValueError('Downloaded file may be corrupted.')
+#def download_file(remote_root, usr, passwd, local_root, file, overwrite=True):
+#    """
+#    Thanks to 
+#    https://stackoverflow.com/questions/37573483/progress-bar-while-download-file-over-http-with-requests/37573701
+#    """
+#    #Beware of how this is joined!
+#    url = '{0}{1}'.format(remote_root, file)
+#    ofile = os.path.join(local_root, file)
+#
+#    if os.path.isfile(ofile):
+#        if overwrite:
+#            warnings.warn('Overwriting existing file: {0}'.format(ofile))
+#            os.remove(ofile)
+#        else:
+#            raise FileExistsError('File already exists.  To overwrite, set overwrite=True.')
+#
+#    print('Downloading: {0}'.format(url))
+#    # Streaming, so we can iterate over the response.
+#    r = requests.get(url, stream=True, auth=(usr, passwd))
+#    # Total size in bytes.
+#    total_size = int(r.headers.get('content-length', 0))
+#    block_size = 1024 #1 Kibibyte
+#    t = tqdm.tqdm(total=total_size, unit='iB', unit_scale=True)
+#    with open(ofile, 'wb') as f:
+#        for data in r.iter_content(block_size):
+#            t.update(len(data))
+#            f.write(data)
+#    t.close()
+#    if total_size != 0 and t.n != total_size:
+#        raise ValueError('Downloaded file may be corrupted.')
 
 
 def main():
 
     from IPython import embed
 
-    usr, acc, passwd = NETRC.authenticators(HOST)
+#    usr, acc, passwd = NETRC.authenticators(HOST)
 
-    local_root = remote_data_file()
-    if not os.path.isdir(local_root):
-        os.makedirs(local_root)
+    local_root = Path(remote_data_file()).resolve()
+    if not local_root.exists():
+        local_root.mkdir(parents=True)
+
+    dr = 'DR17'
+    url_root = f'https://data.sdss.org/sas/{dr.lower()}/manga/spectro'
 
     # DRP files
     drp_files = remote_drp_test_files()
     drp_images = remote_drp_test_images()
     plates = [f.split('-')[1] for f in drp_files]
     for plate, fcube, fimg in zip(plates, drp_files, drp_images):
-        if os.path.isfile(os.path.join(local_root, fcube)):
-            warnings.warn('{0} exists.  Skipping...'.format(fcube))
+        local_file = local_root / fcube
+        if local_file.exists():
+            warnings.warn(f'{local_file.name} exists.  Skipping...')
         else:
-            url_root = 'https://{0}/sas/mangawork/manga/spectro/redux/{1}/{2}/stack/'.format(
-                            HOST, drp_test_version, plate)
-            download_file(url_root, usr, passwd, local_root, fcube)
-        if os.path.isfile(os.path.join(local_root, fimg)):
-            warnings.warn('{0} exists.  Skipping...'.format(fimg))
+            url = f'{url_root}/redux/{drp_test_version}/{plate}/stack/{fcube}'
+            download_file(url, local_file)
+
+        local_file = local_root / fimg
+        if local_file.exists():
+            warnings.warn(f'{local_file.name} exists.  Skipping...')
         else:
-            url_root = 'https://{0}/sas/mangawork/manga/spectro/redux/{1}/{2}/images/'.format(
-                            HOST, drp_test_version, plate)
-            download_file(url_root, usr, passwd, local_root, fimg)
+            url = f'{url_root}/redux/{drp_test_version}/{plate}/images/{fimg}'
+            download_file(url, local_file)
 
     # DAP files
     dap_files = remote_dap_test_files(daptype=dap_test_daptype)
     plates = [f.split('-')[1] for f in dap_files]
     ifus = [f.split('-')[2] for f in dap_files]
     for plate, ifu, f in zip(plates, ifus, dap_files):
-        if os.path.isfile(os.path.join(local_root, f)):
-            warnings.warn('{0} exists.  Skipping...'.format(f))
+        local_file = local_root / f
+        if local_file.exists():
+            warnings.warn(f'{local_file.name} exists.  Skipping...')
             continue
-        url_root = 'https://{0}/sas/mangawork/manga/spectro/analysis/{1}/{2}/{3}/{4}/{5}/'.format(
-                        HOST, drp_test_version, dap_test_version, dap_test_daptype, plate, ifu)
-        download_file(url_root, usr, passwd, local_root, f)
+
+        url = f'{url_root}/analysis/{drp_test_version}/{dap_test_version}/{dap_test_daptype}' \
+              f'/{plate}/{ifu}/{f}'
+        download_file(url, local_file)
 
     # DRPall file
-    f = 'drpall-{0}.fits'.format(drp_test_version)
-    url_root = 'https://{0}/sas/mangawork/manga/spectro/redux/{1}/'.format(HOST, drp_test_version)
-    if os.path.isfile(os.path.join(local_root, f)):
-        warnings.warn('{0} exists.  Skipping...'.format(f))
-    else:    
-        download_file(url_root, usr, passwd, local_root, f)
+    local_file = local_root / f'drpall-{drp_test_version}.fits'
+    if local_file.exists():
+        warnings.warn(f'{local_file.name} exists.  Skipping...')
+    else:
+        url = f'{url_root}/redux/{drp_test_version}/{local_file.name}'
+        download_file(url, local_file)
+
+    # DAPall file
+    local_file = local_root / f'dapall-{drp_test_version}-{dap_test_version}.fits'
+    if local_file.exists():
+        warnings.warn(f'{local_file.name} exists.  Skipping...')
+    else:
+        url = f'{url_root}/analysis/{drp_test_version}/{dap_test_version}/{local_file.name}'
+        download_file(url, local_file)
 
 if __name__ == '__main__':
     main()

--- a/download_test_data.py
+++ b/download_test_data.py
@@ -11,54 +11,10 @@ from nirvana.tests.util import remote_data_file, remote_drp_test_files, remote_d
 from nirvana.tests.util import remote_dap_test_files
 from nirvana.tests.util import drp_test_version, dap_test_version, dap_test_daptype
 
-## TODO: Change this to use the (now) public data
-#try:
-#    NETRC = netrc.netrc()
-#except Exception as e:
-#    raise FileNotFoundError('Could not load ~/.netrc file.') from e
-#
-#HOST = 'data.sdss.org'
-#if HOST not in NETRC.hosts:
-#    raise ValueError('Host data.sdss.org is not defined in your ~/.netrc file.')
-
-
-#def download_file(remote_root, usr, passwd, local_root, file, overwrite=True):
-#    """
-#    Thanks to 
-#    https://stackoverflow.com/questions/37573483/progress-bar-while-download-file-over-http-with-requests/37573701
-#    """
-#    #Beware of how this is joined!
-#    url = '{0}{1}'.format(remote_root, file)
-#    ofile = os.path.join(local_root, file)
-#
-#    if os.path.isfile(ofile):
-#        if overwrite:
-#            warnings.warn('Overwriting existing file: {0}'.format(ofile))
-#            os.remove(ofile)
-#        else:
-#            raise FileExistsError('File already exists.  To overwrite, set overwrite=True.')
-#
-#    print('Downloading: {0}'.format(url))
-#    # Streaming, so we can iterate over the response.
-#    r = requests.get(url, stream=True, auth=(usr, passwd))
-#    # Total size in bytes.
-#    total_size = int(r.headers.get('content-length', 0))
-#    block_size = 1024 #1 Kibibyte
-#    t = tqdm.tqdm(total=total_size, unit='iB', unit_scale=True)
-#    with open(ofile, 'wb') as f:
-#        for data in r.iter_content(block_size):
-#            t.update(len(data))
-#            f.write(data)
-#    t.close()
-#    if total_size != 0 and t.n != total_size:
-#        raise ValueError('Downloaded file may be corrupted.')
-
 
 def main():
 
     from IPython import embed
-
-#    usr, acc, passwd = NETRC.authenticators(HOST)
 
     local_root = Path(remote_data_file()).resolve()
     if not local_root.exists():
@@ -115,6 +71,7 @@ def main():
     else:
         url = f'{url_root}/analysis/{drp_test_version}/{dap_test_version}/{local_file.name}'
         download_file(url, local_file)
+
 
 if __name__ == '__main__':
     main()

--- a/nirvana/data/bin2d.py
+++ b/nirvana/data/bin2d.py
@@ -142,7 +142,9 @@ class VoronoiBinning:
         return binid
 
 
-# TODO: Include an optional weight map?
+# TODO:
+#   - Include an optional weight map?
+#   - Include covariance
 class Bin2D:
     r"""
     A utility class for handling two-dimensional binning.

--- a/nirvana/data/kinematics.py
+++ b/nirvana/data/kinematics.py
@@ -1085,6 +1085,8 @@ class Kinematics:
         vel_mask[vel_didnotuse] = bitmask.turn_on(vel_mask[vel_didnotuse], 'DIDNOTUSE')
         vel_mask[vel_largeerr] = bitmask.turn_on(vel_mask[vel_largeerr], 'REJ_ERR')
         vel_mask[vel_lowsnr] = bitmask.turn_on(vel_mask[vel_lowsnr], 'REJ_SNR')
+        if select_coherent:
+            vel_mask[vel_disjoint] = bitmask.turn_on(vel_mask[vel_disjoint], 'DISJOINT')
 
         # If there are not sigma measurements, we're done
         if self.sig is None:
@@ -1095,6 +1097,8 @@ class Kinematics:
         sig_mask[sig_didnotuse] = bitmask.turn_on(sig_mask[sig_didnotuse], 'DIDNOTUSE')
         sig_mask[sig_largeerr] = bitmask.turn_on(sig_mask[sig_largeerr], 'REJ_ERR')
         sig_mask[sig_lowsnr] = bitmask.turn_on(sig_mask[sig_lowsnr], 'REJ_SNR')
+        if select_coherent:
+            sig_mask[sig_disjoint] = bitmask.turn_on(sig_mask[sig_disjoint], 'DISJOINT')
 
         # Done    
         return vel_mask, sig_mask

--- a/nirvana/data/kinematics.py
+++ b/nirvana/data/kinematics.py
@@ -1235,6 +1235,7 @@ class Kinematics:
         ax.axes.get_xaxis().set_visible(False)
         ax.axes.get_yaxis().set_visible(False)
 
+        # TODO: This is MaNGa specific!
         if galmeta is not None:
             ax.text(0.00, -0.05, 'MaNGA ID:', ha='left', va='center', transform=ax.transAxes,
                     fontsize=10)
@@ -1403,6 +1404,7 @@ class Kinematics:
                          None, None, None, None, \
                          None, None
 
+        # TODO: bin sigma^2 and then take sqrt instead?
         # Convert to corrected dispersion
         sig = np.sqrt(self.sig_phys2)
         sigwgt = 4*self.sig_phys2*self.sig_phys2_ivar

--- a/nirvana/data/kinematics.py
+++ b/nirvana/data/kinematics.py
@@ -1267,9 +1267,9 @@ class Kinematics:
         if ell_r is None:
             major_gpm = select_kinematic_axis(r, th, which='major', r_range='all', wedge=10.)
             major_gpm &= np.logical_not(np.ma.getmaskarray(vel))
-            ell_r = np.amax(r[major_gpm])
+            ell_r = np.amax(r[major_gpm]) if np.any(major_gpm) else -1
         de_x, de_y = disk_ellipse(ell_r, np.radians(pa), np.radians(inc), xc=xc, yc=yc)
-        ellip_gpm = r < ell_r
+        ellip_gpm = None if ell_r < 0 else r < ell_r
 
         # Asymmetry metrics
         fid_grw = np.array([50., 80., 90.])
@@ -1282,19 +1282,20 @@ class Kinematics:
         abs_sig_y, grw_sig_y, fid_sig_y = asymmetry.asymmetry_metrics(sig_y, fid_grw)
         abs_sig_xy, grw_sig_xy, fid_sig_xy = asymmetry.asymmetry_metrics(sig_xy, fid_grw)
 
-        ell_abs_vel_x, ell_grw_vel_x, ell_fid_vel_x \
-                = asymmetry.asymmetry_metrics(vel_x, fid_grw, gpm=ellip_gpm)
-        ell_abs_vel_y, ell_grw_vel_y, ell_fid_vel_y \
-                = asymmetry.asymmetry_metrics(vel_y, fid_grw, gpm=ellip_gpm)
-        ell_abs_vel_xy, ell_grw_vel_xy, ell_fid_vel_xy \
-                = asymmetry.asymmetry_metrics(vel_xy, fid_grw, gpm=ellip_gpm)
+        if ellip_gpm is not None:
+            ell_abs_vel_x, ell_grw_vel_x, ell_fid_vel_x \
+                    = asymmetry.asymmetry_metrics(vel_x, fid_grw, gpm=ellip_gpm)
+            ell_abs_vel_y, ell_grw_vel_y, ell_fid_vel_y \
+                    = asymmetry.asymmetry_metrics(vel_y, fid_grw, gpm=ellip_gpm)
+            ell_abs_vel_xy, ell_grw_vel_xy, ell_fid_vel_xy \
+                    = asymmetry.asymmetry_metrics(vel_xy, fid_grw, gpm=ellip_gpm)
 
-        ell_abs_sig_x, ell_grw_sig_x, ell_fid_sig_x \
-                = asymmetry.asymmetry_metrics(sig_x, fid_grw, gpm=ellip_gpm)
-        ell_abs_sig_y, ell_grw_sig_y, ell_fid_sig_y \
-                = asymmetry.asymmetry_metrics(sig_y, fid_grw, gpm=ellip_gpm)
-        ell_abs_sig_xy, ell_grw_sig_xy, ell_fid_sig_xy \
-                = asymmetry.asymmetry_metrics(sig_xy, fid_grw, gpm=ellip_gpm)
+            ell_abs_sig_x, ell_grw_sig_x, ell_fid_sig_x \
+                    = asymmetry.asymmetry_metrics(sig_x, fid_grw, gpm=ellip_gpm)
+            ell_abs_sig_y, ell_grw_sig_y, ell_fid_sig_y \
+                    = asymmetry.asymmetry_metrics(sig_y, fid_grw, gpm=ellip_gpm)
+            ell_abs_sig_xy, ell_grw_sig_xy, ell_fid_sig_xy \
+                    = asymmetry.asymmetry_metrics(sig_xy, fid_grw, gpm=ellip_gpm)
 
 #        abs_vel_x = np.sort(np.absolute(vel_x.compressed()))
 #        n_vel_x = abs_vel_x.size
@@ -1582,15 +1583,19 @@ class Kinematics:
         ax.step(abs_vel_xy, grw_vel_xy, color='C2', where='post', zorder=3)
         ax.scatter(fid_vel_xy[:3], 1-fid_grw/100, marker='.', s=200, color='C2', zorder=4)
 
-        ax.step(ell_abs_vel_x, ell_grw_vel_x, color='C0', where='post', zorder=3, ls='--', lw=0.5)
-        ax.scatter(ell_fid_vel_x[:3], 1-fid_grw/100, marker='o', s=100, facecolor='none',
-                   edgecolor='C0', zorder=4)
-        ax.step(ell_abs_vel_y, ell_grw_vel_y, color='C1', where='post', zorder=3, ls='--', lw=0.5)
-        ax.scatter(ell_fid_vel_y[:3], 1-fid_grw/100, marker='o', s=100, facecolor='none',
-                   edgecolor='C1', zorder=4)
-        ax.step(ell_abs_vel_xy, ell_grw_vel_xy, color='C2', where='post', zorder=3, ls='--', lw=0.5)
-        ax.scatter(ell_fid_vel_xy[:3], 1-fid_grw/100, marker='o', s=100, facecolor='none',
-                   edgecolor='C2', zorder=4)
+        if ellip_gpm is not None:
+            ax.step(ell_abs_vel_x, ell_grw_vel_x,
+                    color='C0', where='post', zorder=3, ls='--', lw=0.5)
+            ax.scatter(ell_fid_vel_x[:3], 1-fid_grw/100,
+                       marker='o', s=100, facecolor='none', edgecolor='C0', zorder=4)
+            ax.step(ell_abs_vel_y, ell_grw_vel_y,
+                    color='C1', where='post', zorder=3, ls='--', lw=0.5)
+            ax.scatter(ell_fid_vel_y[:3], 1-fid_grw/100,
+                       marker='o', s=100, facecolor='none', edgecolor='C1', zorder=4)
+            ax.step(ell_abs_vel_xy, ell_grw_vel_xy,
+                    color='C2', where='post', zorder=3, ls='--', lw=0.5)
+            ax.scatter(ell_fid_vel_xy[:3], 1-fid_grw/100,
+                       marker='o', s=100, facecolor='none', edgecolor='C2', zorder=4)
 
         ax.text(-0.15, 0.5, '1-Growth', ha='center', va='center', transform=ax.transAxes,
                 rotation='vertical')
@@ -1618,15 +1623,19 @@ class Kinematics:
         ax.step(abs_sig_xy, grw_sig_xy, color='C2', where='post', zorder=3)
         ax.scatter(fid_sig_xy[:3], 1-fid_grw/100, marker='.', s=200, color='C2', zorder=4)
 
-        ax.step(ell_abs_sig_x, ell_grw_sig_x, color='C0', where='post', zorder=3, ls='--', lw=0.5)
-        ax.scatter(ell_fid_sig_x[:3], 1-fid_grw/100, marker='o', s=100, facecolor='none',
-                   edgecolor='C0', zorder=4)
-        ax.step(ell_abs_sig_y, ell_grw_sig_y, color='C1', where='post', zorder=3, ls='--', lw=0.5)
-        ax.scatter(ell_fid_sig_y[:3], 1-fid_grw/100, marker='o', s=100, facecolor='none',
-                   edgecolor='C1', zorder=4)
-        ax.step(ell_abs_sig_xy, ell_grw_sig_xy, color='C2', where='post', zorder=3, ls='--', lw=0.5)
-        ax.scatter(ell_fid_sig_xy[:3], 1-fid_grw/100, marker='o', s=100, facecolor='none',
-                   edgecolor='C2', zorder=4)
+        if ellip_gpm:
+            ax.step(ell_abs_sig_x, ell_grw_sig_x,
+                    color='C0', where='post', zorder=3, ls='--', lw=0.5)
+            ax.scatter(ell_fid_sig_x[:3], 1-fid_grw/100,
+                       marker='o', s=100, facecolor='none', edgecolor='C0', zorder=4)
+            ax.step(ell_abs_sig_y, ell_grw_sig_y,
+                    color='C1', where='post', zorder=3, ls='--', lw=0.5)
+            ax.scatter(ell_fid_sig_y[:3], 1-fid_grw/100,
+                       marker='o', s=100, facecolor='none', edgecolor='C1', zorder=4)
+            ax.step(ell_abs_sig_xy, ell_grw_sig_xy,
+                    color='C2', where='post', zorder=3, ls='--', lw=0.5)
+            ax.scatter(ell_fid_sig_xy[:3], 1-fid_grw/100,
+                       marker='o', s=100, facecolor='none', edgecolor='C2', zorder=4)
 
         ax.text(0.5, -0.08, r'$\Delta \sigma$ [km/s]', ha='center', va='center', transform=ax.transAxes)
         ax.text(0.85, 0.9, r'$\Delta \sigma_x$', ha='left', va='center', transform=ax.transAxes,

--- a/nirvana/data/kinematics.py
+++ b/nirvana/data/kinematics.py
@@ -1572,8 +1572,10 @@ class Kinematics:
         # Velocity asymmetry growth
         ax = plot.init_ax(fig, [0.38, 0.06, 0.29, 0.36], majlen=6, minlen=3, facecolor='0.95',
                           gridcolor='0.9')
-        ax.set_xlim([0., np.amax([fid_vel_x[-2], fid_vel_y[-2], fid_vel_xy[-2],
-                                  ell_fid_vel_x[-2], ell_fid_vel_y[-2], ell_fid_vel_xy[-2]])*1.2])
+        asym90 = np.array([fid_vel_x[-2], fid_vel_y[-2], fid_vel_xy[-2]])
+        if ellip_gpm is not None:
+            asym90 = np.append(asym90, [ell_fid_vel_x[-2], ell_fid_vel_y[-2], ell_fid_vel_xy[-2]])
+        ax.set_xlim([0., np.amax(asym90)*1.2])
         ax.set_ylim([3e-2, 1.01])
         ax.set_yscale('log')
         ax.yaxis.set_major_formatter(logformatter)
@@ -1612,8 +1614,12 @@ class Kinematics:
         # Velocity dispersion asymmetry growth
         ax = plot.init_ax(fig, [0.68, 0.06, 0.29, 0.36], majlen=6, minlen=3, facecolor='0.95',
                           gridcolor='0.9')
-        ax.set_xlim([0., np.amax([fid_sig_x[-2], fid_sig_y[-2], fid_sig_xy[-2],
-                                  ell_fid_sig_x[-2], ell_fid_sig_y[-2], ell_fid_sig_xy[-2]])*1.2])
+        asym90 = np.array([fid_sig_x[-2], fid_sig_y[-2], fid_sig_xy[-2]])
+        if ellip_gpm is not None:
+            asym90 = np.append(asym90, [ell_fid_sig_x[-2], ell_fid_sig_y[-2], ell_fid_sig_xy[-2]])
+        ax.set_xlim([0., np.amax(asym90)*1.2])
+#        ax.set_xlim([0., np.amax([fid_sig_x[-2], fid_sig_y[-2], fid_sig_xy[-2],
+#                                  ell_fid_sig_x[-2], ell_fid_sig_y[-2], ell_fid_sig_xy[-2]])*1.2])
         ax.set_ylim([3e-2, 1.01])
         ax.set_yscale('log')
         ax.yaxis.set_major_formatter(ticker.NullFormatter())

--- a/nirvana/data/kinematics.py
+++ b/nirvana/data/kinematics.py
@@ -1837,7 +1837,10 @@ class Kinematics:
         vrad_mod = None if vel_mod is None else (_vel_mod[indx] - vsys)/np.sin(th[indx])
 
         # Get the binned data
-        binr = np.arange(rstep/2, np.amax(r), rstep)
+        # NOTE: ad hoc maximum radius is meant to mitigate effect of minor axis
+        # points on number radial bins.  This will limit the number of off-axis
+        # points included in galaxies with inclinations > 75 deg.
+        binr = np.arange(rstep/2, min(4*np.amax(vrot_r), np.amax(r)), rstep)
         binw = np.full(binr.size, rstep, dtype=float)
 
         # Projected Velocity profiles

--- a/nirvana/data/kinematics.py
+++ b/nirvana/data/kinematics.py
@@ -1840,7 +1840,7 @@ class Kinematics:
         # NOTE: ad hoc maximum radius is meant to mitigate effect of minor axis
         # points on number radial bins.  This will limit the number of off-axis
         # points included in galaxies with inclinations > 75 deg.
-        maxr = min(4*np.amax(vrot_r), np.amax(r))
+        maxr = min(4*np.amax(vrot_r), np.amax(r)) if len(vrot_r) > 0 else np.amax(r)
         binr = np.array([rstep/2]) if maxr < rstep/2 else np.arange(rstep/2, maxr, rstep)
 #        binr = np.arange(rstep/2, min(4*np.amax(vrot_r), np.amax(r)), rstep)
         binw = np.full(binr.size, rstep, dtype=float)

--- a/nirvana/data/kinematics.py
+++ b/nirvana/data/kinematics.py
@@ -1550,20 +1550,22 @@ class Kinematics:
                 transform=ax.transAxes, fontsize=10)
         ax.text(1.01, -0.19, f'{fid_vel_x[-1]:.1f}, {fid_vel_y[-1]:.1f}, {fid_vel_xy[-1]:.1f}',
                 ha='right', va='center', transform=ax.transAxes, fontsize=10)
-        ax.text(0.00, -0.26, r'$V_{\rm asym}$ (ell.: x, y, xy)', ha='left', va='center',
-                transform=ax.transAxes, fontsize=10)
-        ax.text(1.01, -0.26,
-                f'{ell_fid_vel_x[-1]:.1f}, {ell_fid_vel_y[-1]:.1f}, {ell_fid_vel_xy[-1]:.1f}',
-                ha='right', va='center', transform=ax.transAxes, fontsize=10)
+        if ellip_gpm is not None:
+            ax.text(0.00, -0.26, r'$V_{\rm asym}$ (ell.: x, y, xy)', ha='left', va='center',
+                    transform=ax.transAxes, fontsize=10)
+            ax.text(1.01, -0.26,
+                    f'{ell_fid_vel_x[-1]:.1f}, {ell_fid_vel_y[-1]:.1f}, {ell_fid_vel_xy[-1]:.1f}',
+                    ha='right', va='center', transform=ax.transAxes, fontsize=10)
         ax.text(0.00, -0.33, r'$\sigma_{\rm asym}$ (all: x, y, xy)', ha='left', va='center',
                 transform=ax.transAxes, fontsize=10)
         ax.text(1.01, -0.33, f'{fid_sig_x[-1]:.1f}, {fid_sig_y[-1]:.1f}, {fid_sig_xy[-1]:.1f}',
                 ha='right', va='center', transform=ax.transAxes, fontsize=10)
-        ax.text(0.00, -0.40, r'$\sigma_{\rm asym}$ (ell.: x, y, xy)', ha='left', va='center',
-                transform=ax.transAxes, fontsize=10)
-        ax.text(1.01, -0.40,
-                f'{ell_fid_sig_x[-1]:.1f}, {ell_fid_sig_y[-1]:.1f}, {ell_fid_sig_xy[-1]:.1f}',
-                ha='right', va='center', transform=ax.transAxes, fontsize=10)
+        if ellip_gpm is not None:
+            ax.text(0.00, -0.40, r'$\sigma_{\rm asym}$ (ell.: x, y, xy)', ha='left', va='center',
+                    transform=ax.transAxes, fontsize=10)
+            ax.text(1.01, -0.40,
+                    f'{ell_fid_sig_x[-1]:.1f}, {ell_fid_sig_y[-1]:.1f}, {ell_fid_sig_xy[-1]:.1f}',
+                    ha='right', va='center', transform=ax.transAxes, fontsize=10)
 
         rc('font', size=10)
 

--- a/nirvana/data/kinematics.py
+++ b/nirvana/data/kinematics.py
@@ -194,6 +194,12 @@ class Kinematics:
             neither, or if ``binid`` is provided but ``grid_x`` or
             ``grid_y`` is None.
     """
+
+    tracer = None
+    """
+    Tracer designation.  Undefined by default, but can be set for derived classes.
+    """
+
     # TODO: We should change sb_anr to be just a generic S/N ratio.  I.e.,
     # Kinematics shouldn't care about the type of tracer.
     # TODO: Remove arguments that are redundant with the GlobalPar class?

--- a/nirvana/data/kinematics.py
+++ b/nirvana/data/kinematics.py
@@ -16,7 +16,7 @@ from matplotlib import pyplot, rc, patches, ticker, colors
 import warnings
 
 from .bin2d import Bin2D
-from .util import gaussian_deviates, growth_lim
+from .util import gaussian_deviates, growth_lim, impose_positive_definite
 from ..util import plot
 from ..models import asymmetry
 from ..models.beam import construct_beam, ConvolveFFTW, smear

--- a/nirvana/data/kinematics.py
+++ b/nirvana/data/kinematics.py
@@ -1455,17 +1455,22 @@ class Kinematics:
         abs_vel_x = np.absolute(vel_x.compressed())
         n_vel_x = abs_vel_x.size
         grw_vel_x = 1-(np.arange(n_vel_x)+1)/n_vel_x
-        fid_vel_x = np.percentile(abs_vel_x, fid_grw)
+        fid_vel_x = np.percentile(abs_vel_x, fid_grw) if abs_vel_x.size > 0 \
+                        else -np.ones(fid_grw.size, dtype=float)
 
         abs_vel_y = np.absolute(vel_y.compressed())
         n_vel_y = abs_vel_y.size
         grw_vel_y = 1-(np.arange(n_vel_y)+1)/n_vel_y
         fid_vel_y = np.percentile(abs_vel_y, fid_grw)
+        fid_vel_y = np.percentile(abs_vel_y, fid_grw) if abs_vel_y.size > 0 \
+                        else -np.ones(fid_grw.size, dtype=float)
 
         abs_vel_xy = np.absolute(vel_xy.compressed())
         n_vel_xy = abs_vel_xy.size
         grw_vel_xy = 1-(np.arange(n_vel_xy)+1)/n_vel_xy
         fid_vel_xy = np.percentile(abs_vel_xy, fid_grw)
+        fid_vel_xy = np.percentile(abs_vel_xy, fid_grw) if abs_vel_xy.size > 0 \
+                        else -np.ones(fid_grw.size, dtype=float)
 
         ax = plot.init_ax(fig, [0.38, 0.06, 0.29, 0.36], majlen=6, minlen=3, facecolor='0.95',
                           gridcolor='0.9')
@@ -1495,17 +1500,20 @@ class Kinematics:
         abs_sig_x = np.absolute(sig_x.compressed())
         n_sig_x = abs_sig_x.size
         grw_sig_x = 1-(np.arange(n_sig_x)+1)/n_sig_x
-        fid_sig_x = np.percentile(abs_sig_x, fid_grw)
+        fid_sig_x = np.percentile(abs_sig_x, fid_grw) if abs_sig_x.size > 0 \
+                        else -np.ones(fid_grw.size, dtype=float)
 
         abs_sig_y = np.absolute(sig_y.compressed())
         n_sig_y = abs_sig_y.size
         grw_sig_y = 1-(np.arange(n_sig_y)+1)/n_sig_y
-        fid_sig_y = np.percentile(abs_sig_y, fid_grw)
+        fid_sig_y = np.percentile(abs_sig_y, fid_grw) if abs_sig_y.size > 0 \
+                        else -np.ones(fid_grw.size, dtype=float)
 
         abs_sig_xy = np.absolute(sig_xy.compressed())
         n_sig_xy = abs_sig_xy.size
         grw_sig_xy = 1-(np.arange(n_sig_xy)+1)/n_sig_xy
-        fid_sig_xy = np.percentile(abs_sig_xy, fid_grw)
+        fid_sig_xy = np.percentile(abs_sig_xy, fid_grw) if abs_sig_xy.size > 0 \
+                        else -np.ones(fid_grw.size, dtype=float)
 
         ax = plot.init_ax(fig, [0.68, 0.06, 0.29, 0.36], majlen=6, minlen=3, facecolor='0.95',
                           gridcolor='0.9')

--- a/nirvana/data/kinematics.py
+++ b/nirvana/data/kinematics.py
@@ -1631,7 +1631,7 @@ class Kinematics:
         ax.step(abs_sig_xy, grw_sig_xy, color='C2', where='post', zorder=3)
         ax.scatter(fid_sig_xy[:3], 1-fid_grw/100, marker='.', s=200, color='C2', zorder=4)
 
-        if ellip_gpm:
+        if ellip_gpm is not None:
             ax.step(ell_abs_sig_x, ell_grw_sig_x,
                     color='C0', where='post', zorder=3, ls='--', lw=0.5)
             ax.scatter(ell_fid_sig_x[:3], 1-fid_grw/100,

--- a/nirvana/data/kinematics.py
+++ b/nirvana/data/kinematics.py
@@ -1559,7 +1559,7 @@ class Kinematics:
             # Observation
             ax.text(0.00, -0.12, 'Observation:', ha='left', va='center', transform=ax.transAxes,
                     fontsize=10)
-            ax.text(1.01, -0.12, f'{galmeta.plate}-{galmeta.ifu}', ha='right', va='center',
+            ax.text(1.01, -0.12, galmeta.plateifu, ha='right', va='center',
                     transform=ax.transAxes, fontsize=10)
         # Observation
         ax.text(0.00, -0.19, r'$V_{\rm asym}$ (all: x, y, xy)', ha='left', va='center',
@@ -1840,7 +1840,9 @@ class Kinematics:
         # NOTE: ad hoc maximum radius is meant to mitigate effect of minor axis
         # points on number radial bins.  This will limit the number of off-axis
         # points included in galaxies with inclinations > 75 deg.
-        binr = np.arange(rstep/2, min(4*np.amax(vrot_r), np.amax(r)), rstep)
+        maxr = min(4*np.amax(vrot_r), np.amax(r))
+        binr = np.array([rstep/2]) if maxr < rstep/2 else np.arange(rstep/2, maxr, rstep)
+#        binr = np.arange(rstep/2, min(4*np.amax(vrot_r), np.amax(r)), rstep)
         binw = np.full(binr.size, rstep, dtype=float)
 
         # Projected Velocity profiles

--- a/nirvana/data/kinematics.py
+++ b/nirvana/data/kinematics.py
@@ -23,7 +23,7 @@ from ..models import asymmetry
 from ..models.beam import construct_beam, ConvolveFFTW, smear
 from ..models.geometry import projected_polar, disk_ellipse
 
-# TODO: Make Kinematics a subclass of Bin2D?
+
 class Kinematics:
     r"""
     Base class to hold data fit by the kinematic model.

--- a/nirvana/data/kinematics.py
+++ b/nirvana/data/kinematics.py
@@ -1313,42 +1313,6 @@ class Kinematics:
             ell_abs_sig_xy, ell_grw_sig_xy, ell_fid_sig_xy \
                     = asymmetry.asymmetry_metrics(sig_xy, fid_grw, gpm=ellip_gpm)
 
-#        abs_vel_x = np.sort(np.absolute(vel_x.compressed()))
-#        n_vel_x = abs_vel_x.size
-#        grw_vel_x = 1-(np.arange(n_vel_x)+1)/n_vel_x
-#        fid_vel_x = np.percentile(abs_vel_x, fid_grw) if abs_vel_x.size > 0 \
-#                        else -np.ones(fid_grw.size, dtype=float)
-
-#        abs_vel_y = np.sort(np.absolute(vel_y.compressed()))
-#        n_vel_y = abs_vel_y.size
-#        grw_vel_y = 1-(np.arange(n_vel_y)+1)/n_vel_y
-#        fid_vel_y = np.percentile(abs_vel_y, fid_grw) if abs_vel_y.size > 0 \
-#                        else -np.ones(fid_grw.size, dtype=float)
-
-#        abs_vel_xy = np.sort(np.absolute(vel_xy.compressed()))
-#        n_vel_xy = abs_vel_xy.size
-#        grw_vel_xy = 1-(np.arange(n_vel_xy)+1)/n_vel_xy
-#        fid_vel_xy = np.percentile(abs_vel_xy, fid_grw) if abs_vel_xy.size > 0 \
-#                        else -np.ones(fid_grw.size, dtype=float)
-
-#        abs_sig_x = np.sort(np.absolute(sig_x.compressed()))
-#        n_sig_x = abs_sig_x.size
-#        grw_sig_x = 1-(np.arange(n_sig_x)+1)/n_sig_x
-#        fid_sig_x = np.percentile(abs_sig_x, fid_grw) if abs_sig_x.size > 0 \
-#                        else -np.ones(fid_grw.size, dtype=float)
-#
-#        abs_sig_y = np.sort(np.absolute(sig_y.compressed()))
-#        n_sig_y = abs_sig_y.size
-#        grw_sig_y = 1-(np.arange(n_sig_y)+1)/n_sig_y
-#        fid_sig_y = np.percentile(abs_sig_y, fid_grw) if abs_sig_y.size > 0 \
-#                        else -np.ones(fid_grw.size, dtype=float)
-#
-#        abs_sig_xy = np.sort(np.absolute(sig_xy.compressed()))
-#        n_sig_xy = abs_sig_xy.size
-#        grw_sig_xy = 1-(np.arange(n_sig_xy)+1)/n_sig_xy
-#        fid_sig_xy = np.percentile(abs_sig_xy, fid_grw) if abs_sig_xy.size > 0 \
-#                        else -np.ones(fid_grw.size, dtype=float)
-
         # Set the extent for the 2D maps
         extent = [np.amax(self.grid_x), np.amin(self.grid_x),
                   np.amin(self.grid_y), np.amax(self.grid_y)]
@@ -1634,8 +1598,6 @@ class Kinematics:
         if ellip_gpm is not None:
             asym90 = np.append(asym90, [ell_fid_sig_x[-2], ell_fid_sig_y[-2], ell_fid_sig_xy[-2]])
         ax.set_xlim([0., np.amax(asym90)*1.2])
-#        ax.set_xlim([0., np.amax([fid_sig_x[-2], fid_sig_y[-2], fid_sig_xy[-2],
-#                                  ell_fid_sig_x[-2], ell_fid_sig_y[-2], ell_fid_sig_xy[-2]])*1.2])
         ax.set_ylim([3e-2, 1.01])
         ax.set_yscale('log')
         ax.yaxis.set_major_formatter(ticker.NullFormatter())

--- a/nirvana/data/manga.py
+++ b/nirvana/data/manga.py
@@ -339,8 +339,7 @@ def manga_files_from_plateifu(plate, ifu, daptype='HYB10-MILESHC-MASTARHC2', dr=
 
 # TODO: Break this into two functions to download the DRPall and DAPall file
 # separately?
-def download_catalogs(dr='DR17', oroot=None, redux_path=None, analysis_path=None, overwrite=True,
-                      sasurl='https://data.sdss.org/sas/mangawork/manga/spectro'):
+def download_catalogs(dr='DR17', oroot=None, redux_path=None, analysis_path=None, overwrite=True):
     """
     Download the two main MaNGA catalog files, the DRPall and DAPall files.
 
@@ -360,8 +359,6 @@ def download_catalogs(dr='DR17', oroot=None, redux_path=None, analysis_path=None
             environmental variable, if it is defined.
         overwrite (:obj:`bool`, optional):
             Overwrite existing files.
-        sasurl (:obj:`str`, optional):
-            Top-level Science Archive Server url with the MaNGA data.
 
     Returns:
         :obj:`tuple`: The names of the two downloaded files: (1) the DRPall
@@ -381,8 +378,10 @@ def download_catalogs(dr='DR17', oroot=None, redux_path=None, analysis_path=None
         # credentials?
         user, acc, password = NETRC.authenticators('data.sdss.org')
         auth = (user, password)
+        sasurl = 'https://data.sdss.org/sas/mangawork/manga/spectro'
     else:
         auth = None
+        sasurl = f'https://data.sdss.org/sas/{dr.lower()}/manga/spectro'
 
     # Get the default relative paths, relative to the top-level reduction and
     # analysis paths
@@ -439,8 +438,7 @@ def download_catalogs(dr='DR17', oroot=None, redux_path=None, analysis_path=None
 
 
 def download_plateifu(plate, ifu, daptype='HYB10-MILESHC-MASTARHC2', dr='DR17', oroot=None, 
-                      redux_path=None, analysis_path=None, overwrite=True,
-                      sasurl='https://data.sdss.org/sas/mangawork/manga/spectro'):
+                      redux_path=None, analysis_path=None, overwrite=True):
     """
     Download the individual plate-ifu MaNGA data files.
 
@@ -471,8 +469,6 @@ def download_plateifu(plate, ifu, daptype='HYB10-MILESHC-MASTARHC2', dr='DR17', 
             environmental variable, if it is defined.
         overwrite (:obj:`bool`, optional):
             Overwrite existing files.
-        sasurl (:obj:`str`, optional):
-            Top-level Science Archive Server url with the MaNGA data.
 
     Returns:
         :obj:`tuple`: The names of the three downloaded files: (1) the DRP
@@ -493,8 +489,10 @@ def download_plateifu(plate, ifu, daptype='HYB10-MILESHC-MASTARHC2', dr='DR17', 
         # credentials?
         user, acc, password = NETRC.authenticators('data.sdss.org')
         auth = (user, password)
+        sasurl = 'https://data.sdss.org/sas/mangawork/manga/spectro'
     else:
         auth = None
+        sasurl = f'https://data.sdss.org/sas/{dr.lower()}/manga/spectro'
 
     # Get the default relative paths
     _, sas_cube_path, sas_image_path, _, sas_maps_path \

--- a/nirvana/data/manga.py
+++ b/nirvana/data/manga.py
@@ -872,6 +872,12 @@ class MaNGAGasKinematics(MaNGAKinematics):
         quiet (:obj:`bool`, optional):
             Suppress printed output.
     """
+
+    tracer = 'Gas'
+    """
+    Tracer name.
+    """
+
     def __init__(self, maps_file, cube_file=None, image_file=None, psf_ext='RPSF', line='Ha-6564',
                  mask_flags='any', flux_bound=None, sb_fill=None, covar=False,
                  positive_definite=False, quiet=False, fwhm_only=False):
@@ -1053,6 +1059,12 @@ class MaNGAStellarKinematics(MaNGAKinematics):
         quiet (:obj:`bool`, optional):
             Suppress printed output.
     """
+
+    tracer = 'Stars'
+    """
+    Tracer name.
+    """
+
     def __init__(self, maps_file, cube_file=None, image_file=None, psf_ext='GPSF',
                  mask_flags='any', unbinned_sb=True, sb_fill=None, covar=False,
                  positive_definite=False, quiet=False, fwhm_only=False):

--- a/nirvana/data/manga.py
+++ b/nirvana/data/manga.py
@@ -1249,9 +1249,9 @@ class MaNGAGlobalPar(GlobalPar):
                 dapall_file = manga_file_names(plate, ifu, dr=dr)[3]
                 if dapall_path is None:
                     # Get the default path
-                    dapall_path = manga_paths(plate, ifu, dr=dr, redux_path=redux_path)[3]
+                    dapall_path = manga_paths(plate, ifu, dr=dr, analysis_path=analysis_path)[3]
                 if dapall_path is None:
-                    raise ValueError('Could not define path to the DRPall file.')
+                    raise ValueError('Could not define path to the DAPall file.')
                 dapall_file = os.path.join(dapall_path, dapall_file)
             # For the redshift used by the DAP, we actually need the DAPall file
             print('Reading DAPall file ...')

--- a/nirvana/data/util.py
+++ b/nirvana/data/util.py
@@ -229,7 +229,7 @@ def is_positive_definite(mat, quiet=True, quick=True):
     Returns:
         :obj:`bool`: Flag that matrix is positive definite.
     """
-    _mat = mat.toarray() if isinstance(mat, sparse.csr.csr_matrix) else mat
+    _mat = mat.toarray() if isinstance(mat, sparse.csr_matrix) else mat
 
     if quick:
         try:
@@ -273,7 +273,7 @@ def cinv(mat, check_finite=False, upper=False):
         `numpy.ndarray`_: Inverse or upper-triangle decomposition of the input
         matrix, depending on ``upper``.
     """
-    _mat = mat.toarray() if isinstance(mat, sparse.csr.csr_matrix) else mat
+    _mat = mat.toarray() if isinstance(mat, sparse.csr_matrix) else mat
     # This uses scipy.linalg, not numpy.linalg
     cho = linalg.cholesky(_mat, check_finite=check_finite)
     # Returns an upper triangle matrix that can be used to construct the inverse matrix (see below)

--- a/nirvana/data/util.py
+++ b/nirvana/data/util.py
@@ -896,6 +896,8 @@ def find_largest_coherent_region(a):
         selects pixels that are part of the largest coherent group.
     """
     labels, n = ndimage.label(a, structure=np.ones((3,3), dtype=int))
+    if n == 0:
+        raise ValueError('No coherent regions found!')
     if n == 1:
         return labels == 1
 

--- a/nirvana/data/util.py
+++ b/nirvana/data/util.py
@@ -420,7 +420,9 @@ def construct_ivar_weights(error, eps=None):
     return wgts
 
 
-# TODO: Allow one to include covariance in all the stats functions below?
+# TODO:
+#   - Allow one to include covariance in all the stats functions below?
+#   - Remove weights, only allow errors/covariance?
 
 
 def aggregate_stats(x, y, ye=None, wgts=None, gpm=None, eps=None, fill_value=None):
@@ -481,11 +483,13 @@ def aggregate_stats(x, y, ye=None, wgts=None, gpm=None, eps=None, fill_value=Non
 
     # Weighted statistics
     # TODO: Include covariance
+    #   - Requires lots of error propagation!
     wsum = np.sum(_wgts[indx])
     ewxbin = np.dot(_wgts[indx],x[indx])/wsum
     ewmean = np.dot(_wgts[indx],y[indx])/wsum
     ewsdev = np.dot(_wgts[indx],y[indx]**2)/wsum - ewmean**2
     ewsdev = fill_value if ewsdev < 0 or nbin <= 1 else np.sqrt(ewsdev*nbin/(nbin-1))
+    # TODO: This assumes the weights provided are errors...
     ewerr = np.sqrt(1./wsum)
 
     return uwmed, uwmad, uwxbin, uwmean, uwsdev, ewxbin, ewmean, ewsdev, ewerr, nbin, indx

--- a/nirvana/models/asymmetry.py
+++ b/nirvana/models/asymmetry.py
@@ -380,3 +380,20 @@ def onsky_asymmetry_maps(x, y, data, pa=0., ivar=None, mask=None, covar=None, ma
     return tuple(map_diff) if _covar is None else tuple(map_diff + diff_covar)
 
 
+# TODO: Include error and covariance
+def asymmetry_metrics(diff, growth, gpm=None):
+    """
+    Calculate asymmetry map metrics.
+    """
+    _gpm = np.logical_not(np.ma.getmaskarray(diff))
+    if gpm is not None:
+        _gpm &= gpm
+
+    abs_diff = np.sort(np.absolute(np.asarray(diff[_gpm])))
+    n = abs_diff.size
+    grw = 1-(np.arange(n)+1)/n
+    fid = np.percentile(abs_diff, growth) if n > 0 else -np.ones(growth.size, dtype=float)
+    return abs_diff, grw, np.append(fid, np.sqrt(np.mean(abs_diff**2)))
+    
+
+

--- a/nirvana/models/asymmetry.py
+++ b/nirvana/models/asymmetry.py
@@ -389,6 +389,9 @@ def asymmetry_metrics(diff, growth, gpm=None):
     if gpm is not None:
         _gpm &= gpm
 
+    if not np.any(_gpm):
+        return np.array([]), np.array([]), np.zeros(len(growth)+1, dtype=float)
+
     abs_diff = np.sort(np.absolute(np.asarray(diff[_gpm])))
     n = abs_diff.size
     grw = 1-(np.arange(n)+1)/n

--- a/nirvana/models/asymmetry.py
+++ b/nirvana/models/asymmetry.py
@@ -380,7 +380,10 @@ def onsky_asymmetry_maps(x, y, data, pa=0., ivar=None, mask=None, covar=None, ma
     return tuple(map_diff) if _covar is None else tuple(map_diff + diff_covar)
 
 
-# TODO: Include error and covariance
+# TODO:
+#   - Include error and covariance
+#   - Calculate error-weighted RMS
+#   - ... over a specified radius
 def asymmetry_metrics(diff, growth, gpm=None):
     """
     Calculate asymmetry map metrics.

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -1365,6 +1365,7 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
     #   - Projected rotation velocities
     indx = major_gpm & np.logical_not(kin.vel_mask)
     vrot_r = r[indx]
+    vrot_th = th[indx]
     vrot = (kin.vel[indx] - disk.par[4])/np.cos(th[indx])
     #   - Projected radial velocities
     indx = minor_gpm & np.logical_not(kin.vel_mask)
@@ -1930,27 +1931,31 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
         ax.xaxis.set_major_formatter(ticker.NullFormatter())
 
     indx = vrot_nbin > 0
-    ax.scatter(vrot_r, vrot, marker='.', color='k', s=30, lw=0, alpha=0.6, zorder=1)
+#    ax.scatter(vrot_r, vrot, marker='.', color='k', s=30, lw=0, alpha=0.6, zorder=1)
+    app_indx = (vrot_th > np.pi/2) & (vrot_th < 3*np.pi/2)
+    ax.scatter(vrot_r[app_indx], vrot[app_indx], marker='.', color='C0', s=30, lw=0, alpha=0.6, zorder=2)
+    rec_indx = (vrot_th < np.pi/2) | (vrot_th > 3*np.pi/2)
+    ax.scatter(vrot_r[rec_indx], vrot[rec_indx], marker='.', color='C3', s=30, lw=0, alpha=0.6, zorder=2)
     if np.any(indx):
         ax.scatter(binr[indx], vrot_ewmean[indx], marker='o', edgecolors='none', s=100,
-                   alpha=1.0, facecolors='0.5', zorder=3)
-        ax.scatter(binr[indx], vrotm_ewmean[indx], edgecolors='C3', marker='o', lw=3, s=100,
-                   alpha=1.0, facecolors='none', zorder=4)
+                   alpha=1.0, facecolors='0.5', zorder=4)
+        ax.scatter(binr[indx], vrotm_ewmean[indx], edgecolors='blueviolet', marker='o', lw=3, s=100,
+                   alpha=1.0, facecolors='none', zorder=5)
         ax.errorbar(binr[indx], vrot_ewmean[indx], yerr=vrot_ewsdev[indx], color='0.5', capsize=0,
-                    linestyle='', linewidth=1, alpha=1.0, zorder=2)
+                    linestyle='', linewidth=1, alpha=1.0, zorder=3)
     indx = vrad_nbin > 0
-    ax.scatter(vrad_r, vrad, marker='.', color='0.6', s=30, lw=0, alpha=0.6, zorder=1)
+    ax.scatter(vrad_r, vrad, marker='.', color='0.6', s=30, lw=0, alpha=0.6, zorder=2)
     if np.any(indx):
         ax.scatter(binr[indx], vrad_ewmean[indx], marker='o', edgecolors='none', s=100,
-                   alpha=1.0, facecolors='0.7', zorder=3)
+                   alpha=1.0, facecolors='0.7', zorder=4)
         ax.scatter(binr[indx], vradm_ewmean[indx], edgecolors='C1', marker='o', lw=3, s=100,
-                   alpha=1.0, facecolors='none', zorder=4)
+                   alpha=1.0, facecolors='none', zorder=5)
         ax.errorbar(binr[indx], vrad_ewmean[indx], yerr=vrad_ewsdev[indx], color='0.7', capsize=0,
-                    linestyle='', linewidth=1, alpha=1.0, zorder=2)
-    ax.plot(modelr, vrot_intr_model, color='C3', zorder=5, lw=0.5)
+                    linestyle='', linewidth=1, alpha=1.0, zorder=3)
+    ax.plot(modelr, vrot_intr_model, color='blueviolet', zorder=6, lw=0.5)
     if reff_lines is not None:
         for l in reff_lines:
-            ax.axvline(x=l, linestyle='--', lw=0.5, zorder=2, color='k')
+            ax.axvline(x=l, linestyle='--', lw=0.5, zorder=3, color='k')
 
     asec2kpc = galmeta.kpc_per_arcsec()
     if asec2kpc > 0:
@@ -1973,11 +1978,11 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
     axt.yaxis.label.set_color('0.4')
 
     ax.add_patch(patches.Rectangle((0.66,0.55), 0.32, 0.19, facecolor='w', lw=0, edgecolor='none',
-                                   zorder=5, alpha=0.7, transform=ax.transAxes))
+                                   zorder=7, alpha=0.7, transform=ax.transAxes))
     ax.text(0.97, 0.65, r'$V\ \sin i$ [km/s; left axis]', ha='right', va='bottom',
-            transform=ax.transAxes, fontsize=10, zorder=6)
+            transform=ax.transAxes, fontsize=10, zorder=8)
     ax.text(0.97, 0.56, r'$V$ [km/s; right axis]', ha='right', va='bottom', color='0.4',
-            transform=ax.transAxes, fontsize=10, zorder=6)
+            transform=ax.transAxes, fontsize=10, zorder=8)
 
     #-------------------------------------------------------------------
     # Velocity Dispersion profile
@@ -1995,27 +2000,27 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
         plot.rotate_y_ticks(ax, 90, 'center')
 
         indx = sprof_nbin > 0
-        ax.scatter(sprof_r, sprof, marker='.', color='k', s=30, lw=0, alpha=0.6, zorder=1)
+        ax.scatter(sprof_r, sprof, marker='.', color='k', s=30, lw=0, alpha=0.6, zorder=2)
         if np.any(indx):
             ax.scatter(binr[indx], sprof_ewmean[indx], marker='o', edgecolors='none', s=100,
-                       alpha=1.0, facecolors='0.5', zorder=3)
-            ax.scatter(binr[indx], sprofm_ewmean[indx], edgecolors='C3', marker='o', lw=3, s=100,
-                       alpha=1.0, facecolors='none', zorder=4)
+                       alpha=1.0, facecolors='0.5', zorder=4)
+            ax.scatter(binr[indx], sprofm_ewmean[indx], edgecolors='blueviolet',
+                       marker='o', lw=3, s=100, alpha=1.0, facecolors='none', zorder=5)
             ax.errorbar(binr[indx], sprof_ewmean[indx], yerr=sprof_ewsdev[indx], color='0.6',
-                        capsize=0, linestyle='', linewidth=1, alpha=1.0, zorder=2)
-        ax.plot(modelr, sprof_intr_model, color='C3', zorder=5, lw=0.5)
+                        capsize=0, linestyle='', linewidth=1, alpha=1.0, zorder=3)
+        ax.plot(modelr, sprof_intr_model, color='blueviolet', zorder=6, lw=0.5)
         if reff_lines is not None:
             for l in reff_lines:
-                ax.axvline(x=l, linestyle='--', lw=0.5, zorder=2, color='k')
+                ax.axvline(x=l, linestyle='--', lw=0.5, zorder=3, color='k')
 
         ax.text(0.5, -0.13, r'$R$ [arcsec]', ha='center', va='center', transform=ax.transAxes,
                 fontsize=10)
 
         ax.add_patch(patches.Rectangle((0.81,0.86), 0.17, 0.09, facecolor='w', lw=0,
-                                       edgecolor='none', zorder=5, alpha=0.7,
+                                       edgecolor='none', zorder=7, alpha=0.7,
                                        transform=ax.transAxes))
         ax.text(0.97, 0.87, r'$\sigma_{\rm los}$ [km/s]', ha='right', va='bottom',
-                transform=ax.transAxes, fontsize=10, zorder=6)
+                transform=ax.transAxes, fontsize=10, zorder=8)
 
     # TODO:
     #   - Add errors (if available)?

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -828,11 +828,16 @@ def axisym_fit_data(galmeta, kin, p0, lb, ub, disk, vmask, smask, ofile=None):
         fid_sig_xy = asymmetry.asymmetry_metrics(sig_xy, asym_grw)[2]
         #   - ..., within the elliptical radius defined above
         sig_major_gpm = major_gpm & np.logical_not(sigsqr_mask > 0)
-        sig_ell_r = np.amax(r[sig_major_gpm])
-        ellip_gpm = r < sig_ell_r
-        ell_fid_sig_x = asymmetry.asymmetry_metrics(sig_x, asym_grw, gpm=ellip_gpm)[2]
-        ell_fid_sig_y = asymmetry.asymmetry_metrics(sig_y, asym_grw, gpm=ellip_gpm)[2]
-        ell_fid_sig_xy = asymmetry.asymmetry_metrics(sig_xy, asym_grw, gpm=ellip_gpm)[2]
+        if np.any(sig_major_gpm):
+            sig_ell_r = np.amax(r[sig_major_gpm])
+            ellip_gpm = r < sig_ell_r
+            ell_fid_sig_x = asymmetry.asymmetry_metrics(sig_x, asym_grw, gpm=ellip_gpm)[2]
+            ell_fid_sig_y = asymmetry.asymmetry_metrics(sig_y, asym_grw, gpm=ellip_gpm)[2]
+            ell_fid_sig_xy = asymmetry.asymmetry_metrics(sig_xy, asym_grw, gpm=ellip_gpm)[2]
+        else:
+            ell_fid_sig_x = np.zeros(4, dtype=float)
+            ell_fid_sig_y = np.zeros(4, dtype=float)
+            ell_fid_sig_xy = np.zeros(4, dtype=float)
 
     # Construct the model data, both binned data and maps
     models = disk.binned_model(disk.par)

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -974,6 +974,7 @@ def axisym_fit_data(galmeta, kin, p0, lb, ub, disk, vmask, smask, ofile=None):
 
     metadata['VASYM'] = np.array([np.percentile(np.absolute(a[np.logical_not(m)]),
                                                 [50., 80., 90.])
+                                        if not np.all(m) else np.array([-1., -1., -1.])
                                     for a, m in zip(vel_asym, vel_asym_mask)])
     nsig = 0.
 
@@ -998,6 +999,7 @@ def axisym_fit_data(galmeta, kin, p0, lb, ub, disk, vmask, smask, ofile=None):
 
         metadata['SASYM'] = np.array([np.percentile(np.absolute(a[np.logical_not(m)]),
                                                     [50., 80., 90.])
+                                            if not np.all(m) else np.array([-1., -1., -1.])
                                         for a, m in zip(sig_asym, sig_asym_mask)])
         
     # Total fit chi-square. SCHI2 and SNFIT are 0 if sigma not fit because of

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -2706,11 +2706,24 @@ def axisym_iter_fit(galmeta, kin, rctype='HyperbolicTangent', dctype='Exponentia
                              base_ub=np.array([dx/3, dy/3, 350., 89., 500.]))
     print(f'If free, center constrained within +/- {dx/3:.1f} in X and +/- {dy/3:.1f} in Y.')
 
-    # TODO: Handle these issues instead of faulting
-    if np.any(np.less(p0, lb)):
-        raise ValueError('Parameter lower bounds cannot accommodate initial guess value!')
-    if np.any(np.greater(p0, ub)):
-        raise ValueError('Parameter upper bounds cannot accommodate initial guess value!')
+    # Handle boundary violations and warn the user
+    disk_par_names = disk.par_names()
+    indx = np.less(p0, lb)
+    if np.any(indx):
+#        raise ValueError('Parameter lower bounds cannot accommodate initial guess value!')
+        warnings.warn('Adjusting parameters below the lower bound!')
+        for i in np.where(indx)[0]:
+            _p0 = p0[i]
+            p0[i] = lb[i]*1.01
+            print(f'{disk_par_names[i]:>20} {_p0:20.3f} {p0[i]:20.3f}')
+    indx = np.greater(p0, ub)
+    if np.any(indx):
+        warnings.warn('Adjusting parameters above the upper bound!')
+        for i in np.where(indx)[0]:
+            _p0 = p0[i]
+            p0[i] = ub[i]/1.01
+            print(f'{disk_par_names[i]:>20} {_p0:20.3f} {p0[i]:20.3f}')
+#        raise ValueError('Parameter upper bounds cannot accommodate initial guess value!')
 
     #---------------------------------------------------------------------------
     # Setup the masks

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -835,6 +835,7 @@ def axisym_fit_data(galmeta, kin, p0, lb, ub, disk, vmask, smask, ofile=None):
             ell_fid_sig_y = asymmetry.asymmetry_metrics(sig_y, asym_grw, gpm=ellip_gpm)[2]
             ell_fid_sig_xy = asymmetry.asymmetry_metrics(sig_xy, asym_grw, gpm=ellip_gpm)[2]
         else:
+            sig_ell_r = 0.
             ell_fid_sig_x = np.zeros(4, dtype=float)
             ell_fid_sig_y = np.zeros(4, dtype=float)
             ell_fid_sig_xy = np.zeros(4, dtype=float)

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -1468,7 +1468,7 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
     cb = fig.colorbar(im, cax=cax, orientation='horizontal')
     cb.ax.xaxis.set_ticks_position('top')
     cb.ax.xaxis.set_label_position('top')
-    cax.text(-0.05, 1.1, 'V', ha='right', va='center', transform=cax.transAxes)
+    cax.text(-0.05, 1.1, r'$V$', ha='right', va='center', transform=cax.transAxes)
 
     #-------------------------------------------------------------------
     # Velocity Dispersion
@@ -1516,7 +1516,7 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
     cb = fig.colorbar(im, cax=cax, orientation='horizontal')
     cb.ax.xaxis.set_ticks_position('top')
     cb.ax.xaxis.set_label_position('top')
-    cax.text(-0.05, 1.1, 'V', ha='right', va='center', transform=cax.transAxes)
+    cax.text(-0.05, 1.1, r'$V_m$', ha='right', va='center', transform=cax.transAxes)
 
     #-------------------------------------------------------------------
     # Velocity Dispersion Model
@@ -1542,7 +1542,7 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
         cax = fig.add_axes([0.440, 0.57, 0.15, 0.005])
         cax.tick_params(which='both', direction='in')
         cb = fig.colorbar(im, cax=cax, orientation='horizontal', format=logformatter)
-        cax.text(-0.05, 0.1, r'$\sigma$', ha='right', va='center', transform=cax.transAxes)
+        cax.text(-0.05, 0.1, r'$\sigma_m$', ha='right', va='center', transform=cax.transAxes)
 
     #-------------------------------------------------------------------
     # Velocity Model Residuals

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -528,6 +528,7 @@ def _fit_meta_dtype(par_names, nr, parbitmask):
     mp = [(f'M_{n}'.upper(), parbitmask.minimum_dtype()) for n in par_names]
     
     return [('MANGAID', '<U30'),
+            ('PLATEIFU', '<U12'),
             ('PLATE', np.int16),
             ('IFU', np.int16),
             ('OBJRA', np.float),
@@ -914,6 +915,7 @@ def axisym_fit_data(galmeta, kin, p0, lb, ub, disk, vmask, smask, ofile=None):
 
     # Fill the fit-independent data
     metadata['MANGAID'] = galmeta.mangaid
+    metadata['PLATEIFU'] = f'{galmeta.plate}-{galmeta.ifu}'
     metadata['PLATE'] = galmeta.plate
     metadata['IFU'] = galmeta.ifu
     metadata['OBJRA'] = galmeta.ra

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -1744,14 +1744,19 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
 
     #-------------------------------------------------------------------
     # Annotate with the intrinsic scatter included
-    ax.text(0.00, -0.2, r'V scatter, $\epsilon_v$:', ha='left', va='center',
+    # Reduced chi-square
+    ax.text(0.00, -0.2, r'$\chi^2_\nu$', ha='left', va='center', transform=ax.transAxes,
+            fontsize=10)
+    ax.text(1.00, -0.2, f'{rchi2:.2f}', ha='right', va='center', transform=ax.transAxes,
+            fontsize=10)
+    ax.text(0.00, -0.3, r'V scatter, $\epsilon_v$:', ha='left', va='center',
             transform=ax.transAxes, fontsize=10)
-    ax.text(1.00, -0.2, f'{vsct:.1f}', ha='right', va='center', transform=ax.transAxes,
+    ax.text(1.00, -0.3, f'{vsct:.1f}', ha='right', va='center', transform=ax.transAxes,
             fontsize=10)
     if disk.dc is not None:
-        ax.text(0.00, -0.3, r'$\sigma^2$ scatter, $\epsilon_{\sigma^2}$:', ha='left', va='center',
+        ax.text(0.00, -0.4, r'$\sigma^2$ scatter, $\epsilon_{\sigma^2}$:', ha='left', va='center',
                 transform=ax.transAxes, fontsize=10)
-        ax.text(1.00, -0.3, f'{ssct:.1f}', ha='right', va='center', transform=ax.transAxes,
+        ax.text(1.00, -0.4, f'{ssct:.1f}', ha='right', va='center', transform=ax.transAxes,
                 fontsize=10)
 
     #-------------------------------------------------------------------
@@ -1786,86 +1791,86 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
             fontsize=10)
     ax.text(1.01, -0.13, f'{galmeta.plate}-{galmeta.ifu}', ha='right', va='center',
             transform=ax.transAxes, fontsize=10)
+    # Kinematic tracer
+    ax.text(0.00, -0.21, 'Tracer:', ha='left', va='center', transform=ax.transAxes,
+            fontsize=10)
+    ax.text(1.01, -0.21, 'Unknown' if kin.tracer is None else kin.tracer, ha='right', va='center',
+            transform=ax.transAxes, fontsize=10)
     # Sample selection
-    ax.text(0.00, -0.21, 'Sample:', ha='left', va='center', transform=ax.transAxes, fontsize=10)
-    ax.text(1.01, -0.21, f'{sample}', ha='right', va='center', transform=ax.transAxes, fontsize=10)
+    ax.text(0.00, -0.29, 'Sample:', ha='left', va='center', transform=ax.transAxes, fontsize=10)
+    ax.text(1.01, -0.29, f'{sample}', ha='right', va='center', transform=ax.transAxes, fontsize=10)
     # Redshift
-    ax.text(0.00, -0.29, 'Redshift:', ha='left', va='center', transform=ax.transAxes, fontsize=10)
-    ax.text(1.01, -0.29, '{0:.4f}'.format(galmeta.z), ha='right', va='center',
+    ax.text(0.00, -0.37, 'Redshift:', ha='left', va='center', transform=ax.transAxes, fontsize=10)
+    ax.text(1.01, -0.37, '{0:.4f}'.format(galmeta.z), ha='right', va='center',
             transform=ax.transAxes, fontsize=10)
     # Mag
-    ax.text(0.00, -0.37, 'Mag (N,r,i):', ha='left', va='center', transform=ax.transAxes,
+    ax.text(0.00, -0.45, 'Mag (N,r,i):', ha='left', va='center', transform=ax.transAxes,
             fontsize=10)
     if galmeta.mag is None:
-        ax.text(1.01, -0.37, 'Unavailable', ha='right', va='center',
+        ax.text(1.01, -0.45, 'Unavailable', ha='right', va='center',
                 transform=ax.transAxes, fontsize=10)
     else:
-        ax.text(1.01, -0.37, '{0:.1f}/{1:.1f}/{2:.1f}'.format(*galmeta.mag), ha='right',
+        ax.text(1.01, -0.45, '{0:.1f}/{1:.1f}/{2:.1f}'.format(*galmeta.mag), ha='right',
                 va='center', transform=ax.transAxes, fontsize=10)
     # PSF FWHM
-    ax.text(0.00, -0.45, 'FWHM (g,r):', ha='left', va='center', transform=ax.transAxes,
+    ax.text(0.00, -0.53, 'FWHM (g,r):', ha='left', va='center', transform=ax.transAxes,
             fontsize=10)
-    ax.text(1.01, -0.45, '{0:.2f}, {1:.2f}'.format(*galmeta.psf_fwhm[:2]), ha='right', va='center',
+    ax.text(1.01, -0.53, '{0:.2f}, {1:.2f}'.format(*galmeta.psf_fwhm[:2]), ha='right', va='center',
             transform=ax.transAxes, fontsize=10)
     # Sersic n
-    ax.text(0.00, -0.53, r'Sersic $n$:', ha='left', va='center', transform=ax.transAxes,
+    ax.text(0.00, -0.61, r'Sersic $n$:', ha='left', va='center', transform=ax.transAxes,
             fontsize=10)
-    ax.text(1.01, -0.53, '{0:.2f}'.format(galmeta.sersic_n), ha='right', va='center',
+    ax.text(1.01, -0.61, '{0:.2f}'.format(galmeta.sersic_n), ha='right', va='center',
             transform=ax.transAxes, fontsize=10)
     # Stellar Mass
-    ax.text(0.00, -0.61, r'$\log(\mathcal{M}_\ast/\mathcal{M}_\odot$):', ha='left', va='center',
+    ax.text(0.00, -0.69, r'$\log(\mathcal{M}_\ast/\mathcal{M}_\odot$):', ha='left', va='center',
             transform=ax.transAxes, fontsize=10)
-    ax.text(1.01, -0.61, '{0:.2f}'.format(np.log10(galmeta.mass)), ha='right', va='center',
+    ax.text(1.01, -0.69, '{0:.2f}'.format(np.log10(galmeta.mass)), ha='right', va='center',
             transform=ax.transAxes, fontsize=10)
     # Phot Inclination
-    ax.text(0.00, -0.69, r'$i_{\rm phot}$ [deg]', ha='left', va='center', transform=ax.transAxes,
+    ax.text(0.00, -0.77, r'$i_{\rm phot}$ [deg]', ha='left', va='center', transform=ax.transAxes,
             fontsize=10)
-    ax.text(1.01, -0.69, '{0:.1f}'.format(galmeta.guess_inclination(lb=1., ub=89.)),
+    ax.text(1.01, -0.77, '{0:.1f}'.format(galmeta.guess_inclination(lb=1., ub=89.)),
             ha='right', va='center', transform=ax.transAxes, fontsize=10)
     # Fitted center
-    ax.text(0.00, -0.77, r'$x_0$ [arcsec]', ha='left', va='center', transform=ax.transAxes,
+    ax.text(0.00, -0.85, r'$x_0$ [arcsec]', ha='left', va='center', transform=ax.transAxes,
             fontsize=10, color='C3' if _fix[0] else 'k')
     xstr = r'{0:.2f}'.format(disk.par[0]) if _fix[0] \
             else r'{0:.2f} $\pm$ {1:.2f}'.format(disk.par[0], disk.par_err[0])
-    ax.text(1.01, -0.77, xstr,
+    ax.text(1.01, -0.85, xstr,
             ha='right', va='center', transform=ax.transAxes, fontsize=10,
             color='C3' if _fix[0] else 'k')
-    ax.text(0.00, -0.85, r'$y_0$ [arcsec]', ha='left', va='center', transform=ax.transAxes,
+    ax.text(0.00, -0.93, r'$y_0$ [arcsec]', ha='left', va='center', transform=ax.transAxes,
             fontsize=10, color='C3' if _fix[1] else 'k')
     ystr = r'{0:.2f}'.format(disk.par[1]) if _fix[1] \
             else r'{0:.2f} $\pm$ {1:.2f}'.format(disk.par[1], disk.par_err[1])
-    ax.text(1.01, -0.85, ystr,
+    ax.text(1.01, -0.93, ystr,
             ha='right', va='center', transform=ax.transAxes, fontsize=10,
             color='C3' if _fix[1] else 'k')
     # Position angle
-    ax.text(0.00, -0.93, r'$\phi_0$ [deg]', ha='left', va='center', transform=ax.transAxes,
+    ax.text(0.00, -1.01, r'$\phi_0$ [deg]', ha='left', va='center', transform=ax.transAxes,
             fontsize=10, color='C3' if _fix[2] else 'k')
     pastr = r'{0:.1f}'.format(disk.par[2]) if _fix[2] \
             else r'{0:.1f} $\pm$ {1:.1f}'.format(disk.par[2], disk.par_err[2])
-    ax.text(1.01, -0.93, pastr,
+    ax.text(1.01, -1.01, pastr,
             ha='right', va='center', transform=ax.transAxes, fontsize=10,
             color='C3' if _fix[2] else 'k')
     # Kinematic Inclination
-    ax.text(0.00, -1.01, r'$i_{\rm kin}$ [deg]', ha='left', va='center', transform=ax.transAxes,
+    ax.text(0.00, -1.09, r'$i_{\rm kin}$ [deg]', ha='left', va='center', transform=ax.transAxes,
             fontsize=10, color='C3' if _fix[3] else 'k')
     incstr = r'{0:.1f}'.format(disk.par[3]) if _fix[3] \
             else r'{0:.1f} $\pm$ {1:.1f}'.format(disk.par[3], disk.par_err[3])
-    ax.text(1.01, -1.01, incstr,
+    ax.text(1.01, -1.09, incstr,
             ha='right', va='center', transform=ax.transAxes, fontsize=10,
             color='C3' if _fix[3] else 'k')
     # Systemic velocity
-    ax.text(0.00, -1.09, r'$V_{\rm sys}$ [km/s]', ha='left', va='center', transform=ax.transAxes,
+    ax.text(0.00, -1.17, r'$V_{\rm sys}$ [km/s]', ha='left', va='center', transform=ax.transAxes,
             fontsize=10, color='C3' if _fix[4] else 'k')
     vsysstr = r'{0:.1f}'.format(disk.par[4]) if _fix[4] \
             else r'{0:.1f} $\pm$ {1:.1f}'.format(disk.par[4], disk.par_err[4])
-    ax.text(1.01, -1.09, vsysstr,
+    ax.text(1.01, -1.17, vsysstr,
             ha='right', va='center', transform=ax.transAxes, fontsize=10,
             color='C3' if _fix[4] else 'k')
-    # Reduced chi-square
-    ax.text(0.00, -1.17, r'$\chi^2_\nu$', ha='left', va='center', transform=ax.transAxes,
-            fontsize=10)
-    ax.text(1.01, -1.17, f'{rchi2:.2f}', ha='right', va='center', transform=ax.transAxes,
-            fontsize=10)
 
     #-------------------------------------------------------------------
     # Radial plot radius limits

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -537,11 +537,15 @@ def _fit_meta_dtype(par_names, nr, parbitmask):
             ('DAPQUAL', np.int32),
             ('OBJRA', np.float),
             ('OBJDEC', np.float),
+            ('DRPALLINDX', np.int),
+            ('DAPALLINDX', np.int),
             # Redshift used by the DAP to (nominally) offset the velocity field
             # to 0 bulk velocity.
             ('Z', np.float),
             # The conversion factor used to convert arcseconds to kpc
             ('ASEC2KPC', np.float),
+            # The photometric data used; should be elpetro or sersic
+            ('PHOTKEY', '<U8'),
             # NSA-fit effective radius in arcseconds
             ('REFF', np.float),
             # NSA-fit Sersic index
@@ -647,7 +651,7 @@ def _fit_meta_dtype(par_names, nr, parbitmask):
             ('RCHI2', np.float),
             # Status index of the fit returned by scipy.optimize.least_squares
             ('STATUS', np.int),
-            # A simple boolean indication that the fit did not fault
+            # Flag that the fit (scipy.optimize) reported a successful fit
             ('SUCCESS', np.int),
             # Azimuthally binned radial profiles
             ('BINR', float, (nr,)),
@@ -919,7 +923,7 @@ def axisym_fit_data(galmeta, kin, p0, lb, ub, disk, vmask, smask, ofile=None):
 
     # Fill the fit-independent data
     metadata['MANGAID'] = galmeta.mangaid
-    metadata['PLATEIFU'] = f'{galmeta.plate}-{galmeta.ifu}'
+    metadata['PLATEIFU'] = galmeta.plateifu
     metadata['PLATE'] = galmeta.plate
     metadata['IFU'] = galmeta.ifu
     metadata['MNGTARG1'] = galmeta.mngtarg1
@@ -928,8 +932,11 @@ def axisym_fit_data(galmeta, kin, p0, lb, ub, disk, vmask, smask, ofile=None):
     metadata['DAPQUAL'] = galmeta.dapqual
     metadata['OBJRA'] = galmeta.ra
     metadata['OBJDEC'] = galmeta.dec
+    metadata['DRPALLINDX'] = galmeta.drpindx
+    metadata['DAPALLINDX'] = galmeta.dapindx
     metadata['Z'] = galmeta.z
     metadata['ASEC2KPC'] = galmeta.kpc_per_arcsec()
+    metadata['PHOTKEY'] = galmeta.phot_key
     metadata['REFF'] = galmeta.reff
     metadata['SERSICN'] = galmeta.sersic_n
     metadata['PA'] = galmeta.pa
@@ -1114,7 +1121,7 @@ def axisym_fit_data(galmeta, kin, p0, lb, ub, disk, vmask, smask, ofile=None):
         psfhdr['PSFNAME'] = (kin.psf_name, 'Original PSF name, if known')
     #   - Table header
     tblhdr = prihdr.copy()
-    tblhdr['PHOT_KEY'] = 'none' if galmeta.phot_key is None else galmeta.phot_key
+#    tblhdr['PHOT_KEY'] = 'none' if galmeta.phot_key is None else galmeta.phot_key
     disk.pbm.to_header(tblhdr)
 
     hdus = [fits.PrimaryHDU(header=prihdr),
@@ -1800,7 +1807,7 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
     # Observation
     ax.text(0.00, -0.13, 'Observation:', ha='left', va='center', transform=ax.transAxes,
             fontsize=10)
-    ax.text(1.01, -0.13, f'{galmeta.plate}-{galmeta.ifu}', ha='right', va='center',
+    ax.text(1.01, -0.13, galmeta.plateifu, ha='right', va='center',
             transform=ax.transAxes, fontsize=10)
     # Kinematic tracer
     ax.text(0.00, -0.21, 'Tracer:', ha='left', va='center', transform=ax.transAxes,
@@ -2433,7 +2440,7 @@ def axisym_fit_plot_masks(galmeta, kin, disk, vel_mask, sig_mask, ofile=None):
     # Observation
     ax.text(0.00, -0.13, 'Observation:', ha='left', va='center', transform=ax.transAxes,
             fontsize=10)
-    ax.text(1.01, -0.13, f'{galmeta.plate}-{galmeta.ifu}', ha='right', va='center',
+    ax.text(1.01, -0.13, galmeta.plateifu, ha='right', va='center',
             transform=ax.transAxes, fontsize=10)
     # Sample selection
     ax.text(0.00, -0.21, 'Sample:', ha='left', va='center', transform=ax.transAxes, fontsize=10)

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -531,14 +531,14 @@ def _fit_meta_dtype(par_names, nr, parbitmask):
             ('PLATEIFU', '<U12'),
             ('PLATE', np.int16),
             ('IFU', np.int16),
+            ('DRPALLINDX', np.int),
+            ('DAPALLINDX', np.int),
             ('MNGTARG1', np.int32),
             ('MNGTARG3', np.int32),
             ('DRP3QUAL', np.int32),
             ('DAPQUAL', np.int32),
             ('OBJRA', np.float),
             ('OBJDEC', np.float),
-            ('DRPALLINDX', np.int),
-            ('DAPALLINDX', np.int),
             # Redshift used by the DAP to (nominally) offset the velocity field
             # to 0 bulk velocity.
             ('Z', np.float),
@@ -926,14 +926,14 @@ def axisym_fit_data(galmeta, kin, p0, lb, ub, disk, vmask, smask, ofile=None):
     metadata['PLATEIFU'] = galmeta.plateifu
     metadata['PLATE'] = galmeta.plate
     metadata['IFU'] = galmeta.ifu
+    metadata['DRPALLINDX'] = galmeta.drpindx
+    metadata['DAPALLINDX'] = galmeta.dapindx
     metadata['MNGTARG1'] = galmeta.mngtarg1
     metadata['MNGTARG3'] = galmeta.mngtarg3
     metadata['DRP3QUAL'] = galmeta.drp3qual
     metadata['DAPQUAL'] = galmeta.dapqual
     metadata['OBJRA'] = galmeta.ra
     metadata['OBJDEC'] = galmeta.dec
-    metadata['DRPALLINDX'] = galmeta.drpindx
-    metadata['DAPALLINDX'] = galmeta.dapindx
     metadata['Z'] = galmeta.z
     metadata['ASEC2KPC'] = galmeta.kpc_per_arcsec()
     metadata['PHOTKEY'] = galmeta.phot_key

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -775,19 +775,25 @@ def axisym_fit_data(galmeta, kin, p0, lb, ub, disk, vmask, smask, ofile=None):
 
     #   - Asymmetry growth percentiles
     asym_grw = np.array([50., 80., 90.])
-    #   - Set a maximum radius for some data (asymmetry metrics)
-    major_gpm = select_kinematic_axis(r, th, which='major', r_range='all', wedge=10.)
-    vel_major_gpm = major_gpm & np.logical_not(vel_mask > 0)
-    vel_ell_r = np.amax(r[vel_major_gpm])
-    ellip_gpm = r < vel_ell_r
-    #   - Velocity asymmetry metrics, entire map
+    #   - Velocity asymmetry metrics for the entire map
     fid_vel_x = asymmetry.asymmetry_metrics(vel_x, asym_grw)[2]
     fid_vel_y = asymmetry.asymmetry_metrics(vel_y, asym_grw)[2]
     fid_vel_xy = asymmetry.asymmetry_metrics(vel_xy, asym_grw)[2]
-    #   - ..., within the elliptical radius defined above
-    ell_fid_vel_x = asymmetry.asymmetry_metrics(vel_x, asym_grw, gpm=ellip_gpm)[2]
-    ell_fid_vel_y = asymmetry.asymmetry_metrics(vel_y, asym_grw, gpm=ellip_gpm)[2]
-    ell_fid_vel_xy = asymmetry.asymmetry_metrics(vel_xy, asym_grw, gpm=ellip_gpm)[2]
+    #   - Set a maximum radius for some data (asymmetry metrics)
+    major_gpm = select_kinematic_axis(r, th, which='major', r_range='all', wedge=10.)
+    vel_major_gpm = major_gpm & np.logical_not(vel_mask > 0)
+    if np.any(vel_major_gpm):
+        vel_ell_r = np.amax(r[vel_major_gpm])
+        ellip_gpm = r < vel_ell_r
+        #   - Velocity asymmetry metrics within the elliptical radius defined above
+        ell_fid_vel_x = asymmetry.asymmetry_metrics(vel_x, asym_grw, gpm=ellip_gpm)[2]
+        ell_fid_vel_y = asymmetry.asymmetry_metrics(vel_y, asym_grw, gpm=ellip_gpm)[2]
+        ell_fid_vel_xy = asymmetry.asymmetry_metrics(vel_xy, asym_grw, gpm=ellip_gpm)[2]
+    else:
+        vel_ell_r = 0.
+        ell_fid_vel_x = np.zeros(4, dtype=float)
+        ell_fid_vel_y = np.zeros(4, dtype=float)
+        ell_fid_vel_xy = np.zeros(4, dtype=float)
 
     #   - Corrected velocity dispersion squared
     if disk.dc is None:

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -531,6 +531,10 @@ def _fit_meta_dtype(par_names, nr, parbitmask):
             ('PLATEIFU', '<U12'),
             ('PLATE', np.int16),
             ('IFU', np.int16),
+            ('MNGTARG1', np.int32),
+            ('MNGTARG3', np.int32),
+            ('DRP3QUAL', np.int32),
+            ('DAPQUAL', np.int32),
             ('OBJRA', np.float),
             ('OBJDEC', np.float),
             # Redshift used by the DAP to (nominally) offset the velocity field
@@ -918,6 +922,10 @@ def axisym_fit_data(galmeta, kin, p0, lb, ub, disk, vmask, smask, ofile=None):
     metadata['PLATEIFU'] = f'{galmeta.plate}-{galmeta.ifu}'
     metadata['PLATE'] = galmeta.plate
     metadata['IFU'] = galmeta.ifu
+    metadata['MNGTARG1'] = galmeta.mngtarg1
+    metadata['MNGTARG3'] = galmeta.mngtarg3
+    metadata['DRP3QUAL'] = galmeta.drp3qual
+    metadata['DAPQUAL'] = galmeta.dapqual
     metadata['OBJRA'] = galmeta.ra
     metadata['OBJDEC'] = galmeta.dec
     metadata['Z'] = galmeta.z
@@ -2701,7 +2709,8 @@ def axisym_iter_fit(galmeta, kin, rctype='HyperbolicTangent', dctype='Exponentia
     # galaxies can be off center, but the detail here and how well it works
     # hasn't been well tested.
     # TODO: Should this use grid_x instead, so that it's more uniform for all
-    # IFUs?  Or should this be set as a fraction of Reff?
+    # IFUs?  Or should this be set as a fraction of Reff?  Should this be
+    # restricted to the unmasked data?
     dx = np.mean([abs(np.amin(kin.x)), abs(np.amax(kin.x))])
     dy = np.mean([abs(np.amin(kin.y)), abs(np.amax(kin.y))])
     lb, ub = disk.par_bounds(base_lb=np.array([-dx/3, -dy/3, -350., 1., -500.]),

--- a/nirvana/models/axisym.py
+++ b/nirvana/models/axisym.py
@@ -1043,10 +1043,6 @@ def axisym_fit_data(galmeta, kin, p0, lb, ub, disk, vmask, smask, ofile=None):
     metadata['VISCT'] = scat.sig
     metadata['VCHI2'] = np.sum(vfom**2)
 
-#    metadata['VASYM'] = np.array([np.percentile(np.absolute(a[np.logical_not(m)]),
-#                                                [50., 80., 90.])
-#                                        if not np.all(m) else np.array([-1., -1., -1.])
-#                                    for a, m in zip(vel_asym, vel_asym_mask)])
     metadata['VASYM'] = np.vstack((fid_vel_x, fid_vel_y, fid_vel_xy))
     metadata['VASYM_ELL_R'] = vel_ell_r
     metadata['VASYM_ELL'] = np.vstack((ell_fid_vel_x, ell_fid_vel_y, ell_fid_vel_xy))
@@ -1071,11 +1067,6 @@ def axisym_fit_data(galmeta, kin, p0, lb, ub, disk, vmask, smask, ofile=None):
 
         metadata['SISCT'] = scat.sig
         metadata['SCHI2'] = np.sum(sfom**2)
-
-#        metadata['SASYM'] = np.array([np.percentile(np.absolute(a[np.logical_not(m)]),
-#                                                    [50., 80., 90.])
-#                                            if not np.all(m) else np.array([-1., -1., -1.])
-#                                        for a, m in zip(sig_asym, sig_asym_mask)])
 
         metadata['SASYM'] = np.vstack((fid_sig_x, fid_sig_y, fid_sig_xy))
         metadata['SASYM_ELL_R'] = sig_ell_r
@@ -1121,7 +1112,6 @@ def axisym_fit_data(galmeta, kin, p0, lb, ub, disk, vmask, smask, ofile=None):
         psfhdr['PSFNAME'] = (kin.psf_name, 'Original PSF name, if known')
     #   - Table header
     tblhdr = prihdr.copy()
-#    tblhdr['PHOT_KEY'] = 'none' if galmeta.phot_key is None else galmeta.phot_key
     disk.pbm.to_header(tblhdr)
 
     hdus = [fits.PrimaryHDU(header=prihdr),
@@ -1718,48 +1708,6 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
         cb = fig.colorbar(im, cax=cax, orientation='horizontal', format=logformatter)
         cax.text(-0.05, 0.1, r'$\sigma_{\rm b}$', ha='right', va='center', transform=cax.transAxes)
 
-#    #-------------------------------------------------------------------
-#    # Intrinsic Velocity Model
-#    ax = plot.init_ax(fig, [0.800, 0.305, 0.19, 0.19])
-#    cax = fig.add_axes([0.830, 0.50, 0.15, 0.005])
-#    cax.tick_params(which='both', direction='in')
-#    ax.set_xlim(skylim[::-1])
-#    ax.set_ylim(skylim)
-#    ax.xaxis.set_major_formatter(ticker.NullFormatter())
-#    ax.yaxis.set_major_formatter(ticker.NullFormatter())
-#    im = ax.imshow(vmod_intr_map, origin='lower', interpolation='nearest', cmap='RdBu_r',
-#                   extent=extent, vmin=vel_lim[0], vmax=vel_lim[1], zorder=4)
-#    # Mark the fitted dynamical center
-#    ax.scatter(disk.par[0], disk.par[1], marker='+', color='k', s=40, lw=1, zorder=5)
-#    cb = fig.colorbar(im, cax=cax, orientation='horizontal')
-#    cb.ax.xaxis.set_ticks_position('top')
-#    cb.ax.xaxis.set_label_position('top')
-#    cax.text(-0.05, 1.1, 'V', ha='right', va='center', transform=cax.transAxes)
-#
-#    ax.text(0.5, 1.2, 'Intrinsic Model', ha='center', va='center', transform=ax.transAxes,
-#            fontsize=10)
-#
-#    #-------------------------------------------------------------------
-#    # Intrinsic Velocity Dispersion
-#    ax = plot.init_ax(fig, [0.800, 0.110, 0.19, 0.19])
-#    ax.set_xlim(skylim[::-1])
-#    ax.set_ylim(skylim)
-#    ax.xaxis.set_major_formatter(ticker.NullFormatter())
-#    ax.yaxis.set_major_formatter(ticker.NullFormatter())
-#    # Mark the fitted dynamical center
-#    ax.scatter(disk.par[0], disk.par[1], marker='+', color='k', s=40, lw=1, zorder=5)
-#    if disk.dc is None:
-#        ax.text(0.5, 0.3, 'No velocity dispersion model', ha='center', va='center',
-#                transform=ax.transAxes)
-#    else:
-#        im = ax.imshow(smod_intr_map, origin='lower', interpolation='nearest', cmap='viridis',
-#                       extent=extent, norm=colors.LogNorm(vmin=sig_lim[0], vmax=sig_lim[1]),
-#                       zorder=4)
-#        cax = fig.add_axes([0.830, 0.10, 0.15, 0.005])
-#        cax.tick_params(which='both', direction='in')
-#        cb = fig.colorbar(im, cax=cax, orientation='horizontal', format=logformatter)
-#        cax.text(-0.05, 0.1, r'$\sigma$', ha='right', va='center', transform=cax.transAxes)
-
     #-------------------------------------------------------------------
     # Annotate with the intrinsic scatter included
     # Reduced chi-square
@@ -1948,7 +1896,6 @@ def axisym_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=
         ax.xaxis.set_major_formatter(ticker.NullFormatter())
 
     indx = vrot_nbin > 0
-#    ax.scatter(vrot_r, vrot, marker='.', color='k', s=30, lw=0, alpha=0.6, zorder=1)
     app_indx = (vrot_th > np.pi/2) & (vrot_th < 3*np.pi/2)
     ax.scatter(vrot_r[app_indx], vrot[app_indx], marker='.', color='C0', s=30, lw=0, alpha=0.6, zorder=2)
     rec_indx = (vrot_th < np.pi/2) | (vrot_th > 3*np.pi/2)
@@ -2319,8 +2266,6 @@ def axisym_fit_plot_masks(galmeta, kin, disk, vel_mask, sig_mask, ofile=None):
 
     ax = plot.init_ax(fig, [0.410, 0.783, 0.19, 0.19])
     cax = fig.add_axes([0.440, 0.978, 0.15, 0.005])
-#    ax = plot.init_ax(fig, [0.215, 0.580, 0.19, 0.19])
-#    cax = fig.add_axes([0.245, 0.57, 0.15, 0.005])
     cax.tick_params(which='both', direction='in')
     ax.set_xlim(skylim[::-1])
     ax.set_ylim(skylim)
@@ -2728,7 +2673,6 @@ def axisym_iter_fit(galmeta, kin, rctype='HyperbolicTangent', dctype='Exponentia
     disk_par_names = disk.par_names()
     indx = np.less(p0, lb)
     if np.any(indx):
-#        raise ValueError('Parameter lower bounds cannot accommodate initial guess value!')
         warnings.warn('Adjusting parameters below the lower bound!')
         for i in np.where(indx)[0]:
             _p0 = p0[i]
@@ -2741,7 +2685,6 @@ def axisym_iter_fit(galmeta, kin, rctype='HyperbolicTangent', dctype='Exponentia
             _p0 = p0[i]
             p0[i] = ub[i]/1.01
             print(f'{disk_par_names[i]:>20} {_p0:20.3f} {p0[i]:20.3f}')
-#        raise ValueError('Parameter upper bounds cannot accommodate initial guess value!')
 
     #---------------------------------------------------------------------------
     # Setup the masks

--- a/nirvana/models/bisym.py
+++ b/nirvana/models/bisym.py
@@ -1052,7 +1052,7 @@ class BisymmetricDisk(ThinDisk):
             print(f'Fit status message: {fit_message}')
         if self.fit_status is not None:
             print(f'Fit status: {self.fit_status}')
-        print(f'Fit success: {"True" if self.fit_status else "False"}')
+        print(f'Fit success: {str(self.fit_success)}')
         print('-'*10)
         print(f'Base parameters:')
         slc = self._base_slice()

--- a/nirvana/models/bisym.py
+++ b/nirvana/models/bisym.py
@@ -12,7 +12,7 @@ import multiprocessing as mp
 from IPython import embed
 
 import numpy as np
-from scipy import stats, optimize
+from scipy import stats
 
 try:
     from tqdm import tqdm

--- a/nirvana/models/geometry.py
+++ b/nirvana/models/geometry.py
@@ -147,9 +147,9 @@ def disk_ellipse(r, pa, inc, xc=0., yc=0., num=100):
         r (:obj:`float`):
             The semi-major axis radius of the ellipse
         pa (:obj:`float`):
-            The position angle in degrees (from N through E)
+            The position angle in radians (from N through E)
         inc (:obj:`float`):
-            Disk inclination in degrees (0 degree is face-on)
+            Disk inclination in radians (0 is face-on)
         xc (:obj:`float`, optional):
             The Cartesian x coordinate of the center
         yc (:obj:`float`, optional):

--- a/nirvana/models/multitrace.py
+++ b/nirvana/models/multitrace.py
@@ -431,7 +431,7 @@ class MultiTracerDisk:
 
         self._wrkspc_parslc = [self.disk_slice(i) for i in range(self.ntracer)]
         for i in range(self.ntracer):
-            self.disk[i]._init_par(p0[self._wrkspc_parslc[i]], None)
+            self.disk[i]._init_par(self.par[self.untie][self._wrkspc_parslc[i]], None)
             self.disk[i]._init_model(None, self.kin[i].grid_x, self.kin[i].grid_y,
                                      self.kin[i].grid_sb if sb_wgt else None,
                                      self.kin[i].beam_fft, True, None, False)

--- a/nirvana/models/multitrace.py
+++ b/nirvana/models/multitrace.py
@@ -2305,6 +2305,7 @@ def _ad_meta_dtype(nr):
     """
     """
     return [('MANGAID', '<U30'),
+            ('PLATEIFU', '<U12'),
             ('PLATE', np.int16),
             ('IFU', np.int16),
             # Azimuthally binned radial profiles
@@ -2368,6 +2369,7 @@ def asymdrift_fit_data(galmeta, kin, disk, p0, lb, ub, gas_vel_mask, gas_sig_mas
 
     adprof = fileio.init_record_array(1, _ad_meta_dtype(binr.size))
     adprof['MANGAID'] = galmeta.mangaid
+    adprof['PLATEIFU'] = f'{galmeta.plate}-{galmeta.ifu}'
     adprof['PLATE'] = galmeta.plate
     adprof['IFU'] = galmeta.ifu
     adprof['BINR'] = binr

--- a/nirvana/models/multitrace.py
+++ b/nirvana/models/multitrace.py
@@ -11,13 +11,21 @@ from IPython import embed
 
 import numpy as np
 from scipy import optimize
-from .util import cov_err
+from matplotlib import pyplot, rc, patches, ticker, colors
 
+from .geometry import projected_polar
+from ..data.util import select_kinematic_axis, bin_stats, growth_lim, atleast_one_decade
+from .util import cov_err
+from ..util import plot
 
 class MultiTracerDisk:
     """
     Define a class that enables multiple kinematic datasets to be simultaneously
     fit with the ThinDisk models.
+
+    .. todo::
+
+        internals ...
 
     Args:
         disk (array-like):
@@ -55,30 +63,37 @@ class MultiTracerDisk:
         self.np = np.sum([d.np for d in self.disk])
 
         # Setup the ties between base and disk parameters
-        self.tie_base = None
-        self.tie_disk = None
-        self.update_tie_base(tie_base)
-        self.update_tie_disk(tie_disk)
+        self.tie_base = None        # Vector indicating which base parameters to tie between disks
+        self.tie_disk = None        # Vector indicating which disk parameters to tie
+        self.update_tie_base(tie_base)  # Set the base tying strategy
+        self.update_tie_disk(tie_disk)  # Set the disk tying strategy
 
         # Setup the parameters
-        self.par = None
-        self.par_err = None
-        self.global_mask = 0
-        self.fit_status = None
-        self.fit_success = None
+        self.par = None             # Holds the *unique* (untied) parameters
+        self.par_err = None         # Holds any estimated parameter errors
+        # TODO: Set this to the bitmask dtype
+        self.global_mask = 0        # Global bitmask value
+        self.fit_status = None      # Detailed fit status
+        self.fit_success = None     # Simple fit success flag
 
         # Workspace
-        self.disk_fom = None
-        self.disk_jac = None
-        self._wrkspc_parslc = None
-        self._wrkspc_ndata = None
-        self._wrkspc_sdata = None
-        self._wrkspc_jac = None
-
+        self.disk_fom = None        # Functions used to calculate the minimized figure-of-merit
+        self.disk_jac = None        # Functions used to calculate the fit Jacobian
+        self._wrkspc_parslc = None  # Fit workspace: parameter slices
+        self._wrkspc_ndata = None   #   ... Number of data points per dataset
+        self._wrkspc_sdata = None   #   ... Starting indices of each dataset in the concatenation
+        self._wrkspc_jac = None     #   ... Full fit Jacobian
 
     def update_tie_base(self, tie_base):
         """
         Setup parameter tying between the base geometric projection parameters.
+
+        Function sets :attr:`tie_base` and calls :func:`retie`.
+
+        Args:
+            tie_base (array-like):
+                Boolean array indicating which base parameters should be tied
+                between disks.
         """
         # Set the internal
         self.tie_base = np.zeros(self.nbp, dtype=bool) if tie_base is None \
@@ -102,6 +117,8 @@ class MultiTracerDisk:
             - disks must have same class type
             - disks must have the same number of parameters
 
+        Returns:
+            :obj:`bool`: Flag that disk parameters can be tied.
         """
         types = np.array([d.__class__.__name__ for d in self.disk])
         npar = np.array([d.np for d in self.disk])
@@ -110,6 +127,13 @@ class MultiTracerDisk:
     def update_tie_disk(self, tie_disk):
         """
         Setup parameter tying between the disk kinematic parameters
+
+        Function sets :attr:`tie_disk` and calls :func:`retie`.
+
+        Args:
+            tie_disk (array-like):
+                Boolean array indicating which kinematic parameters should be
+                tied between disks.
         """
         # Set the internal
         ndp = self.disk[0].np - self.nbp
@@ -128,11 +152,22 @@ class MultiTracerDisk:
 
     def retie(self):
         """
-        Construct the tying and untying vectors
+        Construct the tying and untying vectors.
 
-        full_par = tied_par[self.untie]
-        tied_par = full_par[self.tie]
+        Given the current :attr:`tie_base` and :attr:`tie_disk` arrays, this
+        sets the :attr:`tie` and :attr:`untie` internals.
 
+        If ``full_par`` provides the complete set of parameters, including
+        redundant parameters that are tied and ``tied_par`` par only contains
+        the unique, untied parameters, one can change between them using the
+        :attr:`tie` and :attr:`untie` internal arrays as follows:
+
+        .. code-block:: python
+
+            full_par = tied_par[disk.untie]
+            tied_par = full_par[disk.tie]
+
+        where ``disk`` is an instance of this class.
         """
         # Find the starting index for the parameters of each disk
         s = [0 if i == 0 else np.sum([d.np for d in self.disk[:i]]) for i in range(self.ntracer)]
@@ -162,6 +197,17 @@ class MultiTracerDisk:
         self.nup = self.tie.size
             
     def guess_par(self, full=False):
+        """
+        Return a set of guess parameters based on the guess parameters for each disk.
+
+        Args:
+            full (:obj:`bool`, optional):
+                Flag to return the full set of parameters, not just the unique,
+                untied ones.
+
+        Returns:
+            `numpy.ndarray`_: Guess parameters
+        """
         gp = np.concatenate([d.guess_par() for d in self.disk])
         return gp if full else gp[self.tie]
 
@@ -177,10 +223,8 @@ class MultiTracerDisk:
             p0 (`numpy.ndarray`_):
                 The parameters to use.  The length can be either the total
                 number of parameters (:attr:`np`) or the total number of
-                unique/untied parameters (:attr:`nup`).  If the former, the
-                vector is tied and untied to make sure that the tied parameters
-                are identical.  If None, the parameters are set by
-                :func:`guess_par`.
+                unique/untied parameters (:attr:`nup`).  If None, the parameters
+                are set by :func:`guess_par`.
             fix (`numpy.ndarray`_):
                 Boolean flags to fix the parameters.  If None or if ``p0`` is
                 None, all parameters are assumed to be free.  If not None, the
@@ -221,8 +265,8 @@ class MultiTracerDisk:
         Args:
             par (`numpy.ndarray`_, optional):
                 The list of parameters to use. Length must be either the total
-                number of *untied* parameters or the total number of free
-                parameters.
+                number of *untied* parameters (:attr:`nup`) or the total number
+                of free parameters (:attr:`nfree`).
         """
         if par.ndim != 1:
             raise ValueError('Parameter array must be a 1D vector.')
@@ -252,12 +296,15 @@ class MultiTracerDisk:
                 verbose=0, assume_posdef_covar=False, ignore_covar=True, analytic_jac=True,
                 maxiter=5):
         """
+        Use non-linear least-squares minimization to simultaneously fit all
+        datasets.
 
         For all input parameter vectors (``p0``, ``fix``, ``lb``, and ``ub``),
         the length of all vectors must be the same, but they can be either the
         total number of parameters (:attr:`np`) or the number of unique (untied)
         parameters (:attr:`nup`).  If the former, note that only the values of
-        the tied parameters in the first disk will be used.
+        the tied parameters in the first disk will be used *regardless of
+        whether or not the parameters are fixed*.
                 
         .. warning::
 
@@ -332,19 +379,24 @@ class MultiTracerDisk:
                 to 1 to ignore these occurences; ``maxiter`` cannot be None.
         """
 
-        # Check the length of scatter
-
+        # Check the input
         self.kin = np.atleast_1d(kin)
         if self.kin.size != self.ntracer:
             raise ValueError('Must provide the same number of kinematic databases as disks '
                              f'({self.ntracer}).')
+        _scatter = np.atleast_1d(scatter)
+        if _scatter.size not in [1, self.ntracer, 2*self.ntracer]:
+            raise ValueError(f'Number of scatter terms must be 1, {self.ntracer}, or '
+                             f'{2*self.ntracer}; found {_scatter.size}.')
 
-        self.disk_fom = [None]*self.ntracer
-        self.disk_jac = [None]*self.ntracer
-
+        # Initialize the parameters.  This checks that the parameters have the
+        # correct length.
         self._init_par(p0, fix)
 
         # Prepare the disks for fitting
+        self.disk_fom = [None]*self.ntracer
+        self.disk_jac = [None]*self.ntracer
+
         for i in range(self.ntracer):
             self.disk[i]._init_model(None, self.kin[i].grid_x, self.kin[i].grid_y,
                                      self.kin[i].grid_sb if sb_wgt else None,
@@ -368,21 +420,97 @@ class MultiTracerDisk:
             jac_kwargs = {'diff_step': np.full(self.nup, 0.01, dtype=float)[self.free]}
 
         # Parameter boundaries
-        lb, ub = self.par_bounds()
-        result = optimize.least_squares(self.fom, self.par[self.free], x_scale='jac', method='trf',
-                                        xtol=1e-12, bounds=(lb[self.free], ub[self.free]), 
-                                        verbose=max(verbose,0), **jac_kwargs)
-        embed()
-        exit()
+        _lb, _ub = self.par_bounds()
+        if lb is None:
+            lb = _lb
+        if ub is None:
+            ub = _ub
+        if len(lb) != self.nup or len(ub) != self.nup:
+            raise ValueError('Length of one or both of the bound vectors is incorrect.')
+
+        # Setup to iteratively fit, where the iterations are meant to ensure
+        # that the least-squares fit actually optimizes the parameters.
+        # - Set the random number generator with a fixed seed so that the
+        #   result is deterministic.
+        rng = np.random.default_rng(seed=909)
+        # - Set the free parameters.  These are save to a new vector so that the
+        #   initial parameters can be tracked for each iteration without losing
+        #   the original input.
+        _p0 = self.par[self.free]
+        p = _p0.copy()
+        # - Reset any parameter errors
+        pe = None
+        # - Start counting the iterations
+        niter = 0
+        while niter < maxiter:
+            # Run the optimization
+            result = optimize.least_squares(self.fom, p, x_scale='jac', method='trf',
+                                            xtol=1e-12, bounds=(lb[self.free], ub[self.free]), 
+                                            verbose=max(verbose,0), **jac_kwargs)
+            # Attempt to calculate the errors
+            try:
+                pe = np.sqrt(np.diag(cov_err(result.jac)))
+            except:
+                warnings.warn('Unable to compute parameter errors from precision matrix.')
+                pe = None
+
+            # The fit should change the input parameters.
+            if np.all(np.absolute(p-result.x) > 1e-3):
+                break
+
+            # If it doesn't, something likely went wrong with the fit.  Perturb
+            # the input guesses a bit and retry.
+            p = _p0 + rng.normal(size=self.nfree)*(pe if pe is not None else 0.1*p0)
+            p = np.clip(p, lb[self.free], ub[self.free])
+            niter += 1
+
+        # TODO: Add something to the fit status/success flags that tests if
+        # niter == maxiter and/or if the input parameters are identical to the
+        # final best-fit prameters?  Note that the input parameters, p0, may not
+        # be identical to the output parameters because of the iterations mean
+        # that p != p0 !
+
+        # Save the fit status
+        self.fit_status = result.status
+        self.fit_success = result.success
+
+        # Save the best-fitting parameters
+        self._set_par(result.x)
+        if pe is None:
+            self.par_err = None
+        else:
+            self.par_err = np.zeros(self.nup, dtype=float)
+            self.par_err[self.free] = pe
+
+        # Print the report
+        if verbose > -1:
+            self.report(fit_message=result.message)
 
     def par_bounds(self):
         """
+        Return the lower and upper bounds for the unique, untied parameters.
+
+        Returns:
+            :obj:`tuple`: A two-tuple of `numpy.ndarray`_ objects with the lower
+            and upper parameter boundaries.
         """
         lb, ub = np.array([list(d.par_bounds()) for d in self.disk]).transpose(1,0,2).reshape(2,-1)
         return lb[self.tie], ub[self.tie]
 
     def fom(self, par):
         """
+        Calculate the figure-of-merit for a model by concatenating the result
+        from the figure-of-merit calculations provided for each disk.  This is
+        the function used by the least-squares optimization in the simultaneous
+        fitting process.
+
+        Args:
+            par (`numpy.ndarray`_):
+                The model parameters; see :func:`_set_par`.
+    
+        Returns:
+            `numpy.ndarray`_: The vector with the model residuals for each
+            fitted data point.
         """
         # Get the tied parameters
         self._set_par(par)
@@ -393,6 +521,15 @@ class MultiTracerDisk:
 
     def jac(self, par):
         """
+        Compute the model Jacobian using the analytic derivatives provided by
+        each disk independently.
+
+        Args:
+            par (`numpy.ndarray`_):
+                The model parameters; see :func:`_set_par`.
+    
+        Returns:
+            `numpy.ndarray`_: The array with the model Jacobian.
         """
         # Get the tied parameters
         self._set_par(par)
@@ -408,13 +545,844 @@ class MultiTracerDisk:
             self._wrkspc_jac[sec] += _jac[i]
         return self._wrkspc_jac[:,self.free]
 
-            
+    def report(self, fit_message=None):
+        """
+        Report the current parameters of the model to the screen.
 
-        
+        Args:
+            fit_message (:obj:`str`, optional):
+                The status message returned by the fit optimization.
+        """
+        if self.par is None:
+            print('No parameters to report.')
+            return
 
-        
+        print('-'*70)
+        print(f'{"Fit Result":^70}')
+        print('-'*70)
+        if fit_message is not None:
+            print(f'Fit status message: {fit_message}')
+        if self.fit_status is not None:
+            print(f'Fit status: {self.fit_status}')
+        print(f'Fit success: {"True" if self.fit_status else "False"}')
+        print('-'*50)
+        # Indicate which parameters are tied
+        if np.any(self.tie_base) or np.any(self.tie_disk):
+            disk0_parn = self.disk[0].par_names()
+            tied = self.tie_base if not np.any(self.tie_disk) \
+                        else np.append(self.tie_base, self.tie_disk)
+            print('Tied Parameters:')
+            for i in range(tied.size):
+                if not tied[i]:
+                    continue
+                print(f'{disk0_parn[i]:>30}')
+        else:
+            print('No tied parameters')
+
+        # Print the results for each disk
+        full_par = self.par[self.untie]
+        full_par_err = None if self.par_err is None else self.par_err[self.untie]
+        full_free = self.free[self.untie]
+        full_free[np.setdiff1d(np.arange(self.np), self.tie)] = False
+        for i in range(self.ntracer):
+            print('-'*50)
+            print(f'{f"Disk {i+1}":^50}')
+            print('-'*50)
+            slc = self._disk_slice(i)
+            self.disk[i].par = full_par[slc]
+            self.disk[i].free = full_free[slc]
+            self.disk[i].par_err = None if full_par_err is None else full_par_err[slc]
+            self.disk[i].report(component=True)
+        print('-'*50)
+
+        resid = self.fom(self.par)
+        chisqr = np.sum(resid**2) / (resid.size - self.nfree)
+        print(f'Total reduced chi-square: {chisqr}')
+        print('-'*70)        
 
 
+# TODO:
+#   - Add keyword for radial sampling for 1D model RCs and dispersion profiles
+#   - This is MaNGA-specific and needs to be abstracted
+#   - Allow the plot to be constructed from the fits file written by
+#     axisym_fit_data
+def asymdrift_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofile=None):
+    """
+    Construct the QA plot for the result of fitting an
+    :class:`~nirvana.model.axisym.AxisymmetricDisk` model to a galaxy.
+
+    Args:
+        galmeta (:class:`~nirvana.data.meta.GlobalPar`):
+            Object with metadata for the galaxy to be fit.
+        kin (:class:`~nirvana.data.kinematics.Kinematics`):
+            Object with the data to be fit
+        disk (:class:`~nirvana.models.axisym.AxisymmetricDisk`):
+            Object that performed the fit and has the best-fitting parameters.
+        par (`numpy.ndarray`_, optional):
+            The parameters of the model.  If None are provided, the parameters
+            in ``disk`` are used.
+        par_err (`numpy.ndarray`_, optional):
+            The errors in the model parameters.  If None are provided, the
+            parameter errors in ``disk`` are used.
+        fix (`numpy.ndarray`_, optional):
+            Flags indicating the parameters that were fixed during the fit.  If
+            None, all parameters are assumed to have been free.
+        ofile (:obj:`str`, optional):
+            Output filename for the plot.  If None, the plot is shown to the
+            screen.
+    """
+    logformatter = plot.get_logformatter()
+
+    # Change the style
+    rc('font', size=8)
+
+    if disk.par is None and par is None:
+        raise ValueError('No model parameters available.  Provide directly or via disk argument.')
+
+    _par = disk.par[disk.untie] if par is None else par
+    if disk.par_err is None and par_err is None:
+        _par_err = np.full(_par.size, -1., dtype=float)
+    else:
+        _par_err = disk.par_err[disk.untie] if par_err is None else par_err
+
+    if fix is None:
+        _fix = np.logical_not(disk.free)[disk.untie]
+        _fix[np.setdiff1d(np.arange(disk.np), disk.tie)] = True
+    else:
+        _fix = fix
+
+    if _par.size != disk.np:
+        raise ValueError('Number of provided parameters has the incorrect size.')
+    if _par_err.size != disk.np:
+        raise ValueError('Number of provided parameter errors has the incorrect size.')
+    if _fix.size != disk.np:
+        raise ValueError('Number of provided parameter fixing flags has the incorrect size.')
+
+    mean_vsys = (_par[4] + _par[disk.disk[0].np+4])/2
+
+    # Build the data to plot
+    fwhm = galmeta.psf_fwhm[1]
+    oversample = 1.5
+    maj_wedge = 30.
+
+    sb_map = [None]*2
+    v_map = [None]*2
+    s_map = [None]*2
+    vmod = [None]*2
+    vmod_map = [None]*2
+    smod = [None]*2
+    smod_map = [None]*2
+
+    spax_vrot_r = [None]*2
+    spax_vrot = [None]*2
+    spax_smaj_r = [None]*2
+    spax_smaj = [None]*2
+
+    bin_r = [None]*2
+    bin_vrot = [None]*2
+    bin_vrote = [None]*2
+    bin_vrotn = [None]*2
+    bin_smaj = [None]*2
+    bin_smaje = [None]*2
+    bin_smajn = [None]*2
+
+    for i in range(2):
+        sb_map[i] = kin[i].remap('sb')
+        v_map[i] = kin[i].remap('vel')
+        s_map[i] = np.ma.sqrt(kin[i].remap('sig_phys2', mask=kin[i].sig_mask))
+
+        # Construct the model data, both binned data and maps
+        slc = disk._disk_slice(i)
+        disk.disk[i].par = _par[slc]
+        models = disk.disk[i].model()
+        if disk.disk[i].dc is None:
+            vmod[i] = kin[i].bin(models)
+            vmod_map[i] = kin[i].remap(vmod[i], mask=kin[i].vel_mask)
+            smod[i] = None
+            smod_map[i] = None
+        else:
+            vmod[i] = kin[i].bin(models[0])
+            vmod_map[i] = kin[i].remap(vmod[i], mask=kin[i].vel_mask)
+            smod[i] = kin[i].bin(models[1])
+            smod_map[i] = kin[i].remap(smod[i], mask=kin[i].sig_mask)
+
+        # Get the projected rotational velocity
+        #   - Disk-plane coordinates
+        r, th = projected_polar(kin[i].x - disk.disk[i].par[0], kin[i].y - disk.disk[i].par[1],
+                                *np.radians(disk.disk[i].par[2:4]))
+        #   - Mask for data along the major axis
+        major_gpm = select_kinematic_axis(r, th, which='major', r_range='all', wedge=maj_wedge)
+        #   - Projected rotation velocities
+        indx = major_gpm & np.logical_not(kin[i].vel_mask)
+        spax_vrot_r[i] = r[indx]
+        spax_vrot[i] = (kin[i].vel[indx] - disk.disk[i].par[4])/np.cos(th[indx])
+        #   - Major axis velocity dispersions
+        indx = major_gpm & np.logical_not(kin[i].sig_mask) & (kin[i].sig_phys2 > 0)
+        spax_smaj_r[i] = r[indx]
+        spax_smaj[i] = np.sqrt(kin[i].sig_phys2[indx])
+
+        bin_r[i], bin_vrot[i], bin_vrote[i], _, bin_vrotn[i], _, _, _, _, _, _, _, _, \
+            _, _, _, _, _, _, bin_smaj[i], bin_smaje[i], _, bin_smajn[i], _, _, _, _, _, _, _, _, \
+                = kin[i].radial_profiles(fwhm/oversample, xc=disk.disk[i].par[0],
+                                         yc=disk.disk[i].par[1], pa=disk.disk[i].par[2],
+                                         inc=disk.disk[i].par[3], vsys=disk.disk[i].par[4],
+                                         maj_wedge=maj_wedge)
+
+    resid = disk.fom(_par[disk.tie])
+    rchisqr = np.sum(resid**2) / (resid.size - disk.nfree)
+
+    r_map, th_map = projected_polar(kin[0].grid_x - disk.disk[0].par[0],
+                                    kin[0].grid_y - disk.disk[0].par[1],
+                                    np.radians(disk.disk[0].par[2]),
+                                    np.radians(disk.disk[0].par[3]))
+
+    ad_map = (v_map[0] - disk.disk[0].par[4])**2 - (v_map[1] - disk.disk[1].par[4])**2
+    ad_map = np.ma.divide(ad_map, np.cos(th_map)**2)
+    admod_map = (vmod_map[0] - disk.disk[0].par[4])**2 - (vmod_map[1] - disk.disk[1].par[4])**2
+    admod_map = np.ma.divide(admod_map, np.cos(th_map)**2)
+
+    ados_map = np.ma.divide(ad_map, kin[1].remap('sig_phys2', mask=kin[1].sig_mask))
+    adosmod_map = np.ma.divide(admod_map, smod_map[1]**2)
+
+    # Get the 1D model profiles
+    maxr = np.amax(np.concatenate(spax_vrot_r+spax_smaj_r))
+    modelr = np.arange(0, maxr, 0.1)
+    vrotm = [None]*2
+    smajm = [None]*2
+    for i in range(2):
+        vrotm[i] = disk.disk[i].rc.sample(modelr, par=disk.disk[i].rc_par())
+        smajm[i] = disk.disk[i].dc.sample(modelr, par=disk.disk[i].dc_par())
+
+    spax_ad_r, spax_ad, bin_ad_r, bin_ad, bin_ade, bin_adn \
+            = asymdrift_radial_profile(disk, kin, fwhm/oversample, maj_wedge=maj_wedge)
+
+    spax_ad = np.ma.sqrt(spax_ad).filled(0.0)
+    bin_ad = np.ma.sqrt(bin_ad).filled(0.0)
+    bin_ade = np.ma.divide(bin_ade, 2*bin_ad).filled(0.0)
+
+    # Set the radius limits for the radial plots
+    r_lim = [0.0, maxr * 1.05]
+    rc_lim = growth_lim(np.concatenate(bin_vrot+vrotm), 0.99, 1.3)
+    smaj_lim = growth_lim(np.ma.log10(np.concatenate(smajm + [bin_ad])).compressed(), 0.9, 1.5)
+    smaj_lim = atleast_one_decade(np.power(10.0, smaj_lim))
+
+    # TODO: Extent may need to be adjusted by 0.25 arcsec!  extent is from the
+    # edge of the pixel, not from its center.
+    # Set the extent for the 2D maps
+    extent = [np.amax(kin[0].grid_x), np.amin(kin[0].grid_x),
+              np.amin(kin[0].grid_y), np.amax(kin[0].grid_y)]
+    Dx = max(extent[0]-extent[1], extent[3]-extent[2]) # *1.01
+    skylim = np.array([ (extent[0]+extent[1] - Dx)/2., 0.0 ])
+    skylim[1] = skylim[0] + Dx
+
+    sb_lim = [growth_lim(np.ma.log10(sb_map[0]).compressed(), 0.90, 1.05),
+              growth_lim(np.ma.log10(sb_map[1]).compressed(), 0.90, 1.05)]
+    sb_lim = [atleast_one_decade(np.power(10.0, sb_lim[0])),
+              atleast_one_decade(np.power(10.0, sb_lim[1]))]
+
+    vel_lim = growth_lim(np.ma.concatenate(v_map+vmod_map).compressed(), 0.90, 1.05,
+                         midpoint=mean_vsys)
+
+    ad_lim = growth_lim(np.ma.log10(np.ma.append(ad_map, admod_map)).compressed(), 0.70, 1.05)
+    ad_lim = atleast_one_decade(np.power(10.0, ad_lim))
+
+    sig_lim = growth_lim(np.ma.log10(np.ma.append(s_map[1], smod_map[1])).compressed(), 0.70, 1.05)
+    sig_lim = atleast_one_decade(np.power(10., sig_lim))
+
+#    ados_lim = np.power(10.0, growth_lim(np.ma.log10(np.ma.append(ados_map, adosmod_map).compressed(),
+#                                        0.80, 1.05)))
+#    ados_lim = atleast_one_decade(sig_lim)
+
+    ados_lim = growth_lim(np.ma.append(ados_map, adosmod_map).compressed(), 0.80, 1.05)
+
+    # Create the plot
+    w,h = pyplot.figaspect(1)
+    fig = pyplot.figure(figsize=(2*w,2*h))
+
+    #-------------------------------------------------------------------
+    # Gas velocity field
+    ax = plot.init_ax(fig, [0.02, 0.775, 0.19, 0.19])
+    cax = fig.add_axes([0.05, 0.97, 0.15, 0.005])
+    cax.tick_params(which='both', direction='in')
+    ax.set_xlim(skylim[::-1])
+    ax.set_ylim(skylim)
+    plot.rotate_y_ticks(ax, 90, 'center')
+    ax.xaxis.set_major_formatter(ticker.NullFormatter())
+    ax.add_patch(patches.Circle((0.1, 0.1), fwhm/np.diff(skylim)[0]/2, transform=ax.transAxes,
+                                facecolor='0.7', edgecolor='k', zorder=4))
+    im = ax.imshow(v_map[0], origin='lower', interpolation='nearest', cmap='RdBu_r',
+                   extent=extent, vmin=vel_lim[0], vmax=vel_lim[1], zorder=4)
+    # Mark the fitted dynamical center
+    ax.scatter(disk.disk[0].par[0], disk.disk[0].par[1],
+               marker='+', color='k', s=40, lw=1, zorder=5)
+    cb = fig.colorbar(im, cax=cax, orientation='horizontal')
+    cb.ax.xaxis.set_ticks_position('top')
+    cb.ax.xaxis.set_label_position('top')
+    ax.text(0.05, 0.90, r'$V_g$', ha='left', va='center', transform=ax.transAxes)
+
+    #-------------------------------------------------------------------
+    # Gas velocity field model
+    ax = plot.init_ax(fig, [0.02, 0.580, 0.19, 0.19])
+    cax = fig.add_axes([0.05, 0.57, 0.15, 0.005])
+    cax.tick_params(which='both', direction='in')
+    ax.set_xlim(skylim[::-1])
+    ax.set_ylim(skylim)
+    plot.rotate_y_ticks(ax, 90, 'center')
+    ax.xaxis.set_major_formatter(ticker.NullFormatter())
+    ax.add_patch(patches.Circle((0.1, 0.1), fwhm/np.diff(skylim)[0]/2, transform=ax.transAxes,
+                                facecolor='0.7', edgecolor='k', zorder=4))
+    im = ax.imshow(vmod_map[0], origin='lower', interpolation='nearest', cmap='RdBu_r',
+                   extent=extent, vmin=vel_lim[0], vmax=vel_lim[1], zorder=4)
+    # Mark the fitted dynamical center
+    ax.scatter(disk.disk[0].par[0], disk.disk[0].par[1],
+               marker='+', color='k', s=40, lw=1, zorder=5)
+    cb = fig.colorbar(im, cax=cax, orientation='horizontal')
+    ax.text(0.05, 0.90, r'$V_{g,m}$', ha='left', va='center', transform=ax.transAxes)
+
+    #-------------------------------------------------------------------
+    # Stellar velocity field
+    ax = plot.init_ax(fig, [0.215, 0.775, 0.19, 0.19])
+    cax = fig.add_axes([0.245, 0.97, 0.15, 0.005])
+    cax.tick_params(which='both', direction='in')
+    ax.set_xlim(skylim[::-1])
+    ax.set_ylim(skylim)
+    ax.xaxis.set_major_formatter(ticker.NullFormatter())
+    ax.yaxis.set_major_formatter(ticker.NullFormatter())
+    ax.add_patch(patches.Circle((0.1, 0.1), fwhm/np.diff(skylim)[0]/2, transform=ax.transAxes,
+                                facecolor='0.7', edgecolor='k', zorder=4))
+    im = ax.imshow(v_map[1], origin='lower', interpolation='nearest', cmap='RdBu_r',
+                   extent=extent, vmin=vel_lim[0], vmax=vel_lim[1], zorder=4)
+    # Mark the fitted dynamical center
+    ax.scatter(disk.disk[1].par[0], disk.disk[1].par[1],
+               marker='+', color='k', s=40, lw=1, zorder=5)
+    cb = fig.colorbar(im, cax=cax, orientation='horizontal')
+    cb.ax.xaxis.set_ticks_position('top')
+    cb.ax.xaxis.set_label_position('top')
+    ax.text(0.05, 0.90, r'$V_\ast$', ha='left', va='center', transform=ax.transAxes)
+
+    #-------------------------------------------------------------------
+    # Stellar velocity field model
+    ax = plot.init_ax(fig, [0.215, 0.580, 0.19, 0.19])
+    cax = fig.add_axes([0.245, 0.57, 0.15, 0.005])
+    cax.tick_params(which='both', direction='in')
+    ax.set_xlim(skylim[::-1])
+    ax.set_ylim(skylim)
+    ax.xaxis.set_major_formatter(ticker.NullFormatter())
+    ax.yaxis.set_major_formatter(ticker.NullFormatter())
+    ax.add_patch(patches.Circle((0.1, 0.1), fwhm/np.diff(skylim)[0]/2, transform=ax.transAxes,
+                                facecolor='0.7', edgecolor='k', zorder=4))
+    im = ax.imshow(vmod_map[1], origin='lower', interpolation='nearest', cmap='RdBu_r',
+                   extent=extent, vmin=vel_lim[0], vmax=vel_lim[1], zorder=4)
+    # Mark the fitted dynamical center
+    ax.scatter(disk.disk[1].par[0], disk.disk[1].par[1],
+               marker='+', color='k', s=40, lw=1, zorder=5)
+    cb = fig.colorbar(im, cax=cax, orientation='horizontal')
+    ax.text(0.05, 0.90, r'$V_{\ast,m}$', ha='left', va='center', transform=ax.transAxes)
+
+    #-------------------------------------------------------------------
+    # Measured AD
+    ax = plot.init_ax(fig, [0.410, 0.775, 0.19, 0.19])
+    cax = fig.add_axes([0.440, 0.97, 0.15, 0.005])
+    cax.tick_params(which='both', direction='in')
+    ax.set_xlim(skylim[::-1])
+    ax.set_ylim(skylim)
+    ax.xaxis.set_major_formatter(ticker.NullFormatter())
+    ax.yaxis.set_major_formatter(ticker.NullFormatter())
+    ax.add_patch(patches.Circle((0.1, 0.1), fwhm/np.diff(skylim)[0]/2, transform=ax.transAxes,
+                                facecolor='0.7', edgecolor='k', zorder=4))
+    im = ax.imshow(ad_map, origin='lower', interpolation='nearest', cmap='viridis',
+                   extent=extent, norm=colors.LogNorm(vmin=ad_lim[0], vmax=ad_lim[1]), zorder=4) 
+    # Mark the fitted dynamical center
+    ax.scatter(disk.disk[0].par[0], disk.disk[0].par[1],
+               marker='+', color='k', s=40, lw=1, zorder=5)
+    cb = fig.colorbar(im, cax=cax, orientation='horizontal', format=logformatter)
+    cb.ax.xaxis.set_ticks_position('top')
+    cb.ax.xaxis.set_label_position('top')
+    ax.text(0.05, 0.90, r'$\sigma^2_a$', ha='left', va='center', transform=ax.transAxes)
+
+    #-------------------------------------------------------------------
+    # AD Model
+    ax = plot.init_ax(fig, [0.410, 0.580, 0.19, 0.19])
+    cax = fig.add_axes([0.440, 0.57, 0.15, 0.005])
+    cax.tick_params(which='both', direction='in')
+    ax.set_xlim(skylim[::-1])
+    ax.set_ylim(skylim)
+    ax.xaxis.set_major_formatter(ticker.NullFormatter())
+    ax.yaxis.set_major_formatter(ticker.NullFormatter())
+    ax.add_patch(patches.Circle((0.1, 0.1), fwhm/np.diff(skylim)[0]/2, transform=ax.transAxes,
+                                facecolor='0.7', edgecolor='k', zorder=4))
+    im = ax.imshow(admod_map, origin='lower', interpolation='nearest', cmap='viridis',
+                   extent=extent, norm=colors.LogNorm(vmin=ad_lim[0], vmax=ad_lim[1]), zorder=4)
+    # Mark the fitted dynamical center
+    ax.scatter(disk.disk[0].par[0], disk.disk[0].par[1],
+               marker='+', color='k', s=40, lw=1, zorder=5)
+    cb = fig.colorbar(im, cax=cax, orientation='horizontal', format=logformatter)
+    ax.text(0.05, 0.90, r'$\sigma^2_{a,m}$', ha='left', va='center', transform=ax.transAxes)
+
+    #-------------------------------------------------------------------
+    # Velocity Dispersion
+    ax = plot.init_ax(fig, [0.605, 0.775, 0.19, 0.19])
+    cax = fig.add_axes([0.635, 0.97, 0.15, 0.005])
+    cax.tick_params(which='both', direction='in')
+    ax.set_xlim(skylim[::-1])
+    ax.set_ylim(skylim)
+    ax.xaxis.set_major_formatter(ticker.NullFormatter())
+    ax.yaxis.set_major_formatter(ticker.NullFormatter())
+    ax.add_patch(patches.Circle((0.1, 0.1), fwhm/np.diff(skylim)[0]/2, transform=ax.transAxes,
+                                facecolor='0.7', edgecolor='k', zorder=4))
+    im = ax.imshow(s_map[1], origin='lower', interpolation='nearest', cmap='viridis',
+                   extent=extent, norm=colors.LogNorm(vmin=sig_lim[0], vmax=sig_lim[1]), zorder=4)
+    # Mark the fitted dynamical center
+    ax.scatter(disk.disk[1].par[0], disk.disk[1].par[1],
+               marker='+', color='k', s=40, lw=1, zorder=5)
+    cb = fig.colorbar(im, cax=cax, orientation='horizontal', format=logformatter)
+    cb.ax.xaxis.set_ticks_position('top')
+    cb.ax.xaxis.set_label_position('top')
+    ax.text(0.05, 0.90, r'$\sigma_\ast$', ha='left', va='center', transform=ax.transAxes)
+ 
+    #-------------------------------------------------------------------
+    # Velocity Dispersion Model
+    ax = plot.init_ax(fig, [0.605, 0.580, 0.19, 0.19])
+    cax = fig.add_axes([0.635, 0.57, 0.15, 0.005])
+    cax.tick_params(which='both', direction='in')
+    ax.set_xlim(skylim[::-1])
+    ax.set_ylim(skylim)
+    ax.xaxis.set_major_formatter(ticker.NullFormatter())
+    ax.yaxis.set_major_formatter(ticker.NullFormatter())
+    ax.add_patch(patches.Circle((0.1, 0.1), fwhm/np.diff(skylim)[0]/2, transform=ax.transAxes,
+                                facecolor='0.7', edgecolor='k', zorder=4))
+    im = ax.imshow(smod_map[1], origin='lower', interpolation='nearest', cmap='viridis',
+                   extent=extent, norm=colors.LogNorm(vmin=sig_lim[0], vmax=sig_lim[1]), zorder=4)
+    cb = fig.colorbar(im, cax=cax, orientation='horizontal', format=logformatter)
+    ax.text(0.05, 0.90, r'$\sigma_{\ast,m}$', ha='left', va='center', transform=ax.transAxes)
+
+    #-------------------------------------------------------------------
+    # AD ratio
+    ax = plot.init_ax(fig, [0.800, 0.775, 0.19, 0.19])
+    cax = fig.add_axes([0.830, 0.97, 0.15, 0.005])
+    cax.tick_params(which='both', direction='in')
+    ax.set_xlim(skylim[::-1])
+    ax.set_ylim(skylim)
+    ax.xaxis.set_major_formatter(ticker.NullFormatter())
+    ax.yaxis.set_major_formatter(ticker.NullFormatter())
+    ax.add_patch(patches.Circle((0.1, 0.1), fwhm/np.diff(skylim)[0]/2, transform=ax.transAxes,
+                                facecolor='0.7', edgecolor='k', zorder=4))
+    im = ax.imshow(ados_map, origin='lower', interpolation='nearest', cmap='viridis',
+                   extent=extent, vmin=ados_lim[0], vmax=ados_lim[1], zorder=4)
+    cb = fig.colorbar(im, cax=cax, orientation='horizontal')
+    cb.ax.xaxis.set_ticks_position('top')
+    cb.ax.xaxis.set_label_position('top')
+    ax.text(0.05, 0.90, r'$\sigma^2_a/\sigma^2_\ast$',
+            ha='left', va='center', transform=ax.transAxes)
+
+    #-------------------------------------------------------------------
+    # Model AD ratio
+    ax = plot.init_ax(fig, [0.800, 0.580, 0.19, 0.19])
+    cax = fig.add_axes([0.830, 0.57, 0.15, 0.005])
+    cax.tick_params(which='both', direction='in')
+    ax.set_xlim(skylim[::-1])
+    ax.set_ylim(skylim)
+    ax.xaxis.set_major_formatter(ticker.NullFormatter())
+    ax.yaxis.set_major_formatter(ticker.NullFormatter())
+    ax.add_patch(patches.Circle((0.1, 0.1), fwhm/np.diff(skylim)[0]/2, transform=ax.transAxes,
+                                facecolor='0.7', edgecolor='k', zorder=4))
+    im = ax.imshow(adosmod_map, origin='lower', interpolation='nearest', cmap='viridis',
+                   extent=extent, vmin=ados_lim[0], vmax=ados_lim[1], zorder=4)
+    cb = fig.colorbar(im, cax=cax, orientation='horizontal')
+    ax.text(0.05, 0.90, r'$\sigma^2_{a,m}/\sigma^2_{\ast,m}$', ha='left', va='center',
+             transform=ax.transAxes)
+
+    #-------------------------------------------------------------------
+    # H-alpha surface-brightness
+    ax = plot.init_ax(fig, [0.800, 0.305, 0.19, 0.19])
+    cax = fig.add_axes([0.830, 0.50, 0.15, 0.005])
+    cax.tick_params(which='both', direction='in')
+    ax.set_xlim(skylim[::-1])
+    ax.set_ylim(skylim)
+    ax.xaxis.set_major_formatter(ticker.NullFormatter())
+    ax.yaxis.set_major_formatter(ticker.NullFormatter())
+    ax.add_patch(patches.Circle((0.1, 0.1), fwhm/np.diff(skylim)[0]/2, transform=ax.transAxes,
+                                facecolor='0.7', edgecolor='k', zorder=4))
+    im = ax.imshow(sb_map[0], origin='lower', interpolation='nearest', cmap='inferno',
+                   extent=extent, norm=colors.LogNorm(vmin=sb_lim[0][0], vmax=sb_lim[0][1]),
+                   zorder=4)
+    # Mark the fitted dynamical center
+    ax.scatter(disk.disk[0].par[0], disk.disk[0].par[1],
+               marker='+', color='k', s=40, lw=1, zorder=5)
+    # TODO: For some reason, the combination of the use of a masked array and
+    # setting the formatter to logformatter leads to weird behavior in the map.
+    # Use something like the "pallete" object described here?
+    #   https://matplotlib.org/stable/gallery/images_contours_and_fields/image_masked.html
+    cb = fig.colorbar(im, cax=cax, orientation='horizontal', format=logformatter)
+    cb.ax.xaxis.set_ticks_position('top')
+    cb.ax.xaxis.set_label_position('top')
+    ax.text(0.05, 0.90, r'$\mu_g$', ha='left', va='center', transform=ax.transAxes)
+
+#    ax.text(0.5, 1.2, 'Intrinsic Model', ha='center', va='center', transform=ax.transAxes,
+#            fontsize=10)
+
+    #-------------------------------------------------------------------
+    # Continuum surface brightness
+    ax = plot.init_ax(fig, [0.800, 0.110, 0.19, 0.19])
+    cax = fig.add_axes([0.830, 0.10, 0.15, 0.005])
+    cax.tick_params(which='both', direction='in')
+    ax.set_xlim(skylim[::-1])
+    ax.set_ylim(skylim)
+    ax.xaxis.set_major_formatter(ticker.NullFormatter())
+    ax.yaxis.set_major_formatter(ticker.NullFormatter())
+    ax.add_patch(patches.Circle((0.1, 0.1), fwhm/np.diff(skylim)[0]/2, transform=ax.transAxes,
+                                facecolor='0.7', edgecolor='k', zorder=4))
+    im = ax.imshow(sb_map[1], origin='lower', interpolation='nearest', cmap='inferno',
+                   extent=extent, norm=colors.LogNorm(vmin=sb_lim[1][0], vmax=sb_lim[1][1]),
+                   zorder=4)
+    # Mark the fitted dynamical center
+    ax.scatter(disk.disk[1].par[0], disk.disk[1].par[1],
+               marker='+', color='k', s=40, lw=1, zorder=5)
+    cb = fig.colorbar(im, cax=cax, orientation='horizontal', format=logformatter)
+    ax.text(0.05, 0.90, r'$\mu_\ast$', ha='left', va='center', transform=ax.transAxes)
+
+#    #-------------------------------------------------------------------
+#    # Annotate with the intrinsic scatter included
+#    ax.text(0.00, -0.2, r'V scatter, $\epsilon_v$:', ha='left', va='center',
+#            transform=ax.transAxes, fontsize=10)
+#    ax.text(1.00, -0.2, f'{vsct:.1f}', ha='right', va='center', transform=ax.transAxes,
+#            fontsize=10)
+#    if disk.dc is not None:
+#        ax.text(0.00, -0.3, r'$\sigma^2$ scatter, $\epsilon_{\sigma^2}$:', ha='left', va='center',
+#                transform=ax.transAxes, fontsize=10)
+#        ax.text(1.00, -0.3, f'{ssct:.1f}', ha='right', va='center', transform=ax.transAxes,
+#                fontsize=10)
+
+    #-------------------------------------------------------------------
+    # SDSS image
+    ax = fig.add_axes([0.01, 0.29, 0.23, 0.23])
+    if kin[0].image is not None:
+        ax.imshow(kin[0].image)
+    else:
+        ax.text(0.5, 0.5, 'No Image', ha='center', va='center', transform=ax.transAxes,
+                fontsize=20)
+
+    ax.text(0.5, 1.05, 'SDSS gri Composite', ha='center', va='center', transform=ax.transAxes,
+            fontsize=10)
+    ax.axes.get_xaxis().set_visible(False)
+    ax.axes.get_yaxis().set_visible(False)
+
+    if galmeta.primaryplus:
+        sample='Primary+'
+    elif galmeta.secondary:
+        sample='Secondary'
+    elif galmeta.ancillary:
+        sample='Ancillary'
+    else:
+        sample='Filler'
+
+    # Assume center, PA, and inclination are tied, and that the systemic velocities are not.
+
+    # MaNGA ID
+    ax.text(0.00, -0.05, 'MaNGA ID:', ha='left', va='center', transform=ax.transAxes, fontsize=10)
+    ax.text(1.01, -0.05, f'{galmeta.mangaid}', ha='right', va='center', transform=ax.transAxes,
+            fontsize=10)
+    # Observation
+    ax.text(0.00, -0.13, 'Observation:', ha='left', va='center', transform=ax.transAxes,
+            fontsize=10)
+    ax.text(1.01, -0.13, f'{galmeta.plate}-{galmeta.ifu}', ha='right', va='center',
+            transform=ax.transAxes, fontsize=10)
+    # Sample selection
+    ax.text(0.00, -0.21, 'Sample:', ha='left', va='center', transform=ax.transAxes, fontsize=10)
+    ax.text(1.01, -0.21, f'{sample}', ha='right', va='center', transform=ax.transAxes, fontsize=10)
+    # Redshift
+    ax.text(0.00, -0.29, 'Redshift:', ha='left', va='center', transform=ax.transAxes, fontsize=10)
+    ax.text(1.01, -0.29, '{0:.4f}'.format(galmeta.z), ha='right', va='center',
+            transform=ax.transAxes, fontsize=10)
+    # Mag
+    ax.text(0.00, -0.37, 'Mag (N,r,i):', ha='left', va='center', transform=ax.transAxes,
+            fontsize=10)
+    if galmeta.mag is None:
+        ax.text(1.01, -0.37, 'Unavailable', ha='right', va='center',
+                transform=ax.transAxes, fontsize=10)
+    else:
+        ax.text(1.01, -0.37, '{0:.1f}/{1:.1f}/{2:.1f}'.format(*galmeta.mag), ha='right',
+                va='center', transform=ax.transAxes, fontsize=10)
+    # PSF FWHM
+    ax.text(0.00, -0.45, 'FWHM (g,r):', ha='left', va='center', transform=ax.transAxes,
+            fontsize=10)
+    ax.text(1.01, -0.45, '{0:.2f}, {1:.2f}'.format(*galmeta.psf_fwhm[:2]), ha='right', va='center',
+            transform=ax.transAxes, fontsize=10)
+    # Sersic n
+    ax.text(0.00, -0.53, r'Sersic $n$:', ha='left', va='center', transform=ax.transAxes,
+            fontsize=10)
+    ax.text(1.01, -0.53, '{0:.2f}'.format(galmeta.sersic_n), ha='right', va='center',
+            transform=ax.transAxes, fontsize=10)
+    # Stellar Mass
+    ax.text(0.00, -0.61, r'$\log(\mathcal{M}_\ast/\mathcal{M}_\odot$):', ha='left', va='center',
+            transform=ax.transAxes, fontsize=10)
+    ax.text(1.01, -0.61, '{0:.2f}'.format(np.log10(galmeta.mass)), ha='right', va='center',
+            transform=ax.transAxes, fontsize=10)
+    # Phot Inclination
+    ax.text(0.00, -0.69, r'$i_{\rm phot}$ [deg]', ha='left', va='center', transform=ax.transAxes,
+            fontsize=10)
+    ax.text(1.01, -0.69, '{0:.1f}'.format(galmeta.guess_inclination(lb=1., ub=89.)),
+            ha='right', va='center', transform=ax.transAxes, fontsize=10)
+    # Fitted center
+    ax.text(0.00, -0.77, r'$x_0$ [arcsec]', ha='left', va='center', transform=ax.transAxes,
+            fontsize=10, color='C3' if _fix[0] else 'k')
+    xstr = r'{0:.2f}'.format(_par[0]) if _fix[0] \
+            else r'{0:.2f} $\pm$ {1:.2f}'.format(_par[0], _par_err[0])
+    ax.text(1.01, -0.77, xstr,
+            ha='right', va='center', transform=ax.transAxes, fontsize=10,
+            color='C3' if _fix[0] else 'k')
+    ax.text(0.00, -0.85, r'$y_0$ [arcsec]', ha='left', va='center', transform=ax.transAxes,
+            fontsize=10, color='C3' if _fix[1] else 'k')
+    ystr = r'{0:.2f}'.format(_par[1]) if _fix[1] \
+            else r'{0:.2f} $\pm$ {1:.2f}'.format(_par[1], _par_err[1])
+    ax.text(1.01, -0.85, ystr,
+            ha='right', va='center', transform=ax.transAxes, fontsize=10,
+            color='C3' if _fix[1] else 'k')
+    # Position angle
+    ax.text(0.00, -0.93, r'$\phi_0$ [deg]', ha='left', va='center', transform=ax.transAxes,
+            fontsize=10, color='C3' if _fix[2] else 'k')
+    pastr = r'{0:.1f}'.format(_par[2]) if _fix[2] \
+            else r'{0:.1f} $\pm$ {1:.1f}'.format(_par[2], _par_err[2])
+    ax.text(1.01, -0.93, pastr,
+            ha='right', va='center', transform=ax.transAxes, fontsize=10,
+            color='C3' if _fix[2] else 'k')
+    # Kinematic Inclination
+    ax.text(0.00, -1.01, r'$i_{\rm kin}$ [deg]', ha='left', va='center', transform=ax.transAxes,
+            fontsize=10, color='C3' if _fix[3] else 'k')
+    incstr = r'{0:.1f}'.format(_par[3]) if _fix[3] \
+            else r'{0:.1f} $\pm$ {1:.1f}'.format(_par[3], _par_err[3])
+    ax.text(1.01, -1.01, incstr,
+            ha='right', va='center', transform=ax.transAxes, fontsize=10,
+            color='C3' if _fix[3] else 'k')
+    # Systemic velocity
+    ax.text(0.00, -1.09, r'$\langle V_{\rm sys}\rangle$ [km/s]',
+            ha='left', va='center', transform=ax.transAxes,
+            fontsize=10, color='k')
+    vsysstr = r'{0:.1f}'.format(mean_vsys)
+    ax.text(1.01, -1.09, vsysstr,
+            ha='right', va='center', transform=ax.transAxes, fontsize=10, color='k')
+    # Reduced chi-square
+    ax.text(0.00, -1.17, r'$\chi^2_\nu$', ha='left', va='center', transform=ax.transAxes,
+            fontsize=10)
+    ax.text(1.01, -1.17, f'{rchisqr:.2f}', ha='right', va='center', transform=ax.transAxes,
+            fontsize=10)
+
+    #-------------------------------------------------------------------
+    # Radial plot radius limits
+    # Select bins with sufficient data
+    vrot_indx = [vrn > 5 for vrn in bin_vrotn]
+    smaj_indx = [smn > 5 for smn in bin_smajn]
+    for i in range(2):
+        if not np.any(vrot_indx[i]):
+            vrot_indx[i] = bin_vrotn[i] > 0
+        if not np.any(smaj_indx[i]):
+            smaj_indx[i] = bin_smajn[i] > 0
+    ad_indx = bin_adn > 5
+    if not np.any(ad_indx):
+        ad_indx = bin_adn > 0
+
+    #-------------------------------------------------------------------
+    # Rotation curves
+    reff_lines = np.arange(galmeta.reff, r_lim[1], galmeta.reff) if galmeta.reff > 1 else None
+
+    ax = plot.init_ax(fig, [0.27, 0.27, 0.51, 0.23], facecolor='0.9', top=False, right=False)
+    ax.set_xlim(r_lim)
+    ax.set_ylim(rc_lim)
+    plot.rotate_y_ticks(ax, 90, 'center')
+    ax.xaxis.set_major_formatter(ticker.NullFormatter())
+
+    # Gas
+    _c = tuple([(1-x)*0.2+x for x in colors.to_rgb('C3')])
+    ax.scatter(spax_vrot_r[0], spax_vrot[0],
+               marker='.', color=_c, s=30, lw=0, alpha=0.6, zorder=1)
+    if np.any(vrot_indx[0]):
+        ax.scatter(bin_r[0][vrot_indx[0]], bin_vrot[0][vrot_indx[0]],
+                   marker='o', s=110, alpha=1.0, color='white', zorder=3)
+        ax.scatter(bin_r[0][vrot_indx[0]], bin_vrot[0][vrot_indx[0]],
+                   marker='o', s=90, alpha=1.0, color='C3', zorder=4)
+        ax.errorbar(bin_r[0][vrot_indx[0]], bin_vrot[0][vrot_indx[0]],
+                    yerr=bin_vrote[0][vrot_indx[0]], color='C3', capsize=0,
+                    linestyle='', linewidth=1, alpha=1.0, zorder=2)
+    ax.plot(modelr, vrotm[0], color='C3', zorder=5, lw=1)
+    # Stars
+    _c = tuple([(1-x)*0.2+x for x in colors.to_rgb('C0')])
+    ax.scatter(spax_vrot_r[1], spax_vrot[1],
+               marker='.', color=_c, s=30, lw=0, alpha=0.6, zorder=1)
+    if np.any(vrot_indx[1]):
+        ax.scatter(bin_r[1][vrot_indx[1]], bin_vrot[1][vrot_indx[1]],
+                   marker='o', s=110, alpha=1.0, color='white', zorder=3)
+        ax.scatter(bin_r[1][vrot_indx[1]], bin_vrot[1][vrot_indx[1]],
+                   marker='o', s=90, alpha=1.0, color='C0', zorder=4)
+        ax.errorbar(bin_r[1][vrot_indx[1]], bin_vrot[1][vrot_indx[1]],
+                    yerr=bin_vrote[1][vrot_indx[1]], color='C0', capsize=0,
+                    linestyle='', linewidth=1, alpha=1.0, zorder=2)
+    ax.plot(modelr, vrotm[1], color='C0', zorder=5, lw=1)
+
+    if reff_lines is not None:
+        for l in reff_lines:
+            ax.axvline(x=l, linestyle='--', lw=0.5, zorder=1, color='k')
+
+    asec2kpc = galmeta.kpc_per_arcsec()
+    if asec2kpc > 0:
+        axt = plot.get_twin(ax, 'x')
+        axt.set_xlim(np.array(r_lim) * galmeta.kpc_per_arcsec())
+        axt.set_ylim(rc_lim)
+        ax.text(0.5, 1.14, r'$R$ [$h^{-1}$ kpc]', ha='center', va='center', transform=ax.transAxes,
+                fontsize=10)
+    else:
+        ax.text(0.5, 1.05, 'kpc conversion unavailable', ha='center', va='center',
+                transform=ax.transAxes, fontsize=10)
+
+#    kin_inc = disk.par[3]
+#    axt = plot.get_twin(ax, 'y')
+#    axt.set_xlim(r_lim)
+#    axt.set_ylim(np.array(rc_lim)/np.sin(np.radians(kin_inc)))
+#    plot.rotate_y_ticks(axt, 90, 'center')
+#    axt.spines['right'].set_color('0.4')
+#    axt.tick_params(which='both', axis='y', colors='0.4')
+#    axt.yaxis.label.set_color('0.4')
+
+    ax.add_patch(patches.Rectangle((0.79,0.45), 0.19, 0.09, facecolor='w', lw=0, edgecolor='none',
+                                   zorder=5, alpha=0.7, transform=ax.transAxes))
+    ax.text(0.97, 0.451, r'$V\ \sin i$ [km/s]', ha='right', va='bottom',
+            transform=ax.transAxes, fontsize=10, zorder=6)
+#    ax.text(0.97, 0.56, r'$V$ [km/s; right axis]', ha='right', va='bottom', color='0.4',
+#            transform=ax.transAxes, fontsize=10, zorder=6)
+
+
+    #-------------------------------------------------------------------
+    # Velocity Dispersion profile
+    ax = plot.init_ax(fig, [0.27, 0.04, 0.51, 0.23], facecolor='0.9')
+    ax.set_xlim(r_lim)
+    ax.set_ylim(sig_lim)#[10,275])
+    ax.set_yscale('log')
+    ax.yaxis.set_major_formatter(logformatter)
+    plot.rotate_y_ticks(ax, 90, 'center')
+
+    # Gas
+    _c = tuple([(1-x)*0.2+x for x in colors.to_rgb('C3')])
+    ax.scatter(spax_smaj_r[0], spax_smaj[0],
+               marker='.', color=_c, s=30, lw=0, alpha=0.6, zorder=1)
+    if np.any(smaj_indx[0]):
+        ax.scatter(bin_r[0][smaj_indx[0]], bin_smaj[0][smaj_indx[0]],
+                   marker='o', s=110, alpha=1.0, color='white', zorder=3)
+        ax.scatter(bin_r[0][smaj_indx[0]], bin_smaj[0][smaj_indx[0]],
+                   marker='o', s=90, alpha=1.0, color='C3', zorder=4)
+        ax.errorbar(bin_r[0][smaj_indx[0]], bin_smaj[0][smaj_indx[0]],
+                    yerr=bin_smaje[0][smaj_indx[0]], color='C3', capsize=0,
+                    linestyle='', linewidth=1, alpha=1.0, zorder=2)
+    ax.plot(modelr, smajm[0], color='C3', zorder=5, lw=1)
+    # Stars
+    _c = tuple([(1-x)*0.2+x for x in colors.to_rgb('C0')])
+    ax.scatter(spax_smaj_r[1], spax_smaj[1],
+               marker='.', color=_c, s=30, lw=0, alpha=0.6, zorder=1)
+    if np.any(smaj_indx[1]):
+        ax.scatter(bin_r[1][smaj_indx[1]], bin_smaj[1][smaj_indx[1]],
+                   marker='o', s=110, alpha=1.0, color='white', zorder=3)
+        ax.scatter(bin_r[1][smaj_indx[1]], bin_smaj[1][smaj_indx[1]],
+                   marker='o', s=90, alpha=1.0, color='C0', zorder=4)
+        ax.errorbar(bin_r[1][smaj_indx[1]], bin_smaj[1][smaj_indx[1]],
+                    yerr=bin_smaje[1][smaj_indx[1]], color='C0', capsize=0,
+                    linestyle='', linewidth=1, alpha=1.0, zorder=2)
+    ax.plot(modelr, smajm[1], color='C0', zorder=5, lw=1)
+    # Sigma AD
+    _c = tuple([(1-x)*0.2+x for x in colors.to_rgb('k')])
+    ax.scatter(spax_ad_r, spax_ad,
+               marker='.', color=_c, s=30, lw=0, alpha=0.6, zorder=1)
+    if np.any(ad_indx):
+        ax.scatter(bin_ad_r[ad_indx], bin_ad[ad_indx],
+                   marker='o', s=110, alpha=1.0, color='white', zorder=3)
+        ax.scatter(bin_ad_r[ad_indx], bin_ad[ad_indx],
+                   marker='o', s=90, alpha=1.0, color='k', zorder=4)
+        ax.errorbar(bin_ad_r[ad_indx], bin_ad[ad_indx], yerr=bin_ade[ad_indx],
+                    color='k', capsize=0, linestyle='', linewidth=1, alpha=1.0, zorder=2)
+    ax.plot(modelr, np.sqrt(vrotm[0]**2 - vrotm[1]**2), color='k', zorder=5, lw=1)
+    if reff_lines is not None:
+        for l in reff_lines:
+            ax.axvline(x=l, linestyle='--', lw=0.5, zorder=1, color='k')
+
+    ax.text(0.5, -0.13, r'$R$ [arcsec]', ha='center', va='center', transform=ax.transAxes,
+            fontsize=10)
+
+    ax.add_patch(patches.Rectangle((0.81,0.86), 0.17, 0.09, facecolor='w', lw=0,
+                                    edgecolor='none', zorder=5, alpha=0.7,
+                                    transform=ax.transAxes))
+    ax.text(0.97, 0.861, r'$\sigma_{\rm maj}$ [km/s]', ha='right', va='bottom',
+            transform=ax.transAxes, fontsize=10, zorder=6)
+
+    # TODO:
+    #   - Add errors (if available)?
+    #   - Surface brightness units?
+
+    if ofile is None:
+        pyplot.show()
+    else:
+        fig.canvas.print_figure(ofile, bbox_inches='tight')
+    fig.clear()
+    pyplot.close(fig)
+
+    # Reset to default style
+    pyplot.rcdefaults()
+
+
+def asymdrift_radial_profile(disk, kin, rstep, maj_wedge=30.):
+    """
+    Construct azimuthally averaged radial profiles of the kinematics.
+    """
+
+    if disk.ntracer != 2:
+        raise NotImplementedError('Must provide two disks, first gas, second stars.')
+    if len(kin) != 2:
+        raise NotImplementedError('Must provide two kinematic datasets, first gas, second stars.')
+
+    if not np.allclose(kin[0].grid_x, kin[1].grid_x) \
+            or not np.allclose(kin[0].grid_y, kin[1].grid_y):
+        raise NotImplementedError('Kinematics datasets must have the same grid sampling!')
+
+    if not np.all(disk.tie_base[:4]):
+        raise NotImplementedError('Disk must have tied the xc, yc, pa, and inc for both tracers.')
+
+    par = disk.par[disk.untie]
+
+    # Disk-plane coordinates
+    r, th = projected_polar(kin[0].grid_x - par[0], kin[0].grid_y - par[1], np.radians(par[2]),
+                            np.radians(par[3]))
+
+    # Mask for data along the major and minor axes
+    major_gpm = select_kinematic_axis(r, th, which='major', r_range='all', wedge=maj_wedge)
+
+    # Set the radial bins
+    binr = np.arange(rstep/2, np.amax(r), rstep)
+    binw = np.full(binr.size, rstep, dtype=float)
+
+    # Projected gas and stellar rotation velocities (within the major axis wedge)
+    gas_vel = kin[0].remap('vel', mask=np.logical_not(disk.disk[0].vel_gpm))
+    gas_vel_ivar = kin[0].remap('vel_ivar',
+                                mask=np.logical_not(disk.disk[0].vel_gpm) | kin[0].vel_mask)
+
+    str_vel = kin[1].remap('vel', mask=np.logical_not(disk.disk[1].vel_gpm))
+    str_vel_ivar = kin[1].remap('vel_ivar',
+                                mask=np.logical_not(disk.disk[1].vel_gpm) | kin[1].vel_mask)
+
+    indx = major_gpm & np.logical_not(np.ma.getmaskarray(gas_vel)) \
+                & np.logical_not(np.ma.getmaskarray(str_vel))
+
+    ad_r = r[indx]
+    gas_vrot = (gas_vel.data[indx] - par[4])/np.cos(th[indx])
+    gas_vrot_ivar = gas_vel_ivar.data[indx]*np.cos(th[indx])**2
+
+    str_vrot = (str_vel.data[indx] - par[disk.disk[0].np+4])/np.cos(th[indx])
+    str_vrot_ivar = str_vel_ivar.data[indx]*np.cos(th[indx])**2
+
+    ad = gas_vrot**2 - str_vrot**2
+    ad_wgt = 1 / 2 / (gas_vrot**2/gas_vrot_ivar + str_vrot**2/str_vrot_ivar)
+#    sini = np.sin(np.radians(par[3]))
+#    ad /= sini
+#    ad_wgt *= sini**2
+    _, _, _, _, _, _, _, ad_ewmean, ad_ewsdev, _, _, ad_nbin, ad_bin_gpm \
+            = bin_stats(ad_r, ad, binr, binw, wgts=ad_wgt, fill_value=0.0) 
+
+    return ad_r, ad, binr, ad_ewmean, ad_ewsdev, ad_nbin
 
 
 

--- a/nirvana/models/multitrace.py
+++ b/nirvana/models/multitrace.py
@@ -809,7 +809,10 @@ def asymdrift_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofi
                                          vsys=disk.disk[i].par[4], maj_wedge=maj_wedge)
 
     # Get the 1D model profiles
-    maxr = np.amax(np.concatenate(spax_vrot_r+spax_smaj_r))
+    # NOTE: This catches cases when there is no data, which makes the plot
+    # useless, but it avoids a fault.
+    maxr = rstep if len(spax_vrot_r) == 0 and len(spax_smaj_r) == 0 \
+                else np.amax(np.concatenate(spax_vrot_r+spax_smaj_r))
     modelr = np.arange(0, maxr, 0.1)
     vrotm = [None]*2
     smajm = [None]*2

--- a/nirvana/models/multitrace.py
+++ b/nirvana/models/multitrace.py
@@ -1623,14 +1623,17 @@ def asymdrift_fit_maps(kin, disk, rstep, par=None, maj_wedge=30.):
     ados_mod_map = kin[1].remap(ados_mod.filled(0.0), mask=ados_mask)
     ados_mod_bc_map = kin[1].remap(ados_mod_bc.filled(0.0), mask=ados_mask)
 
-    # Set the radial bins
-    binr = np.arange(rstep/2, np.amax(r), rstep)
-    binw = np.full(binr.size, rstep, dtype=float)
-
     # Mask data away from the major axes
     major_gpm = select_kinematic_axis(r, th, which='major', r_range='all', wedge=maj_wedge)
     ad_indx = major_gpm & np.logical_not(ad_mask)
     ados_indx = major_gpm & np.logical_not(ados_mask)
+
+    # Set the radial bins
+    # NOTE: ad hoc maximum radius is meant to mitigate effect of minor axis
+    # points on number radial bins.  This will limit the number of off-axis
+    # points included in galaxies with inclinations > 75 deg.
+    binr = np.arange(rstep/2, min(4*np.amax(r[ad_indx]), np.amax(r)), rstep)
+    binw = np.full(binr.size, rstep, dtype=float)
 
     # Bin the data
     _, _, _, _, _, _, _, ad_ewmean, ad_ewsdev, _, _, ad_nbin, _ \

--- a/nirvana/models/multitrace.py
+++ b/nirvana/models/multitrace.py
@@ -2308,6 +2308,10 @@ def _ad_meta_dtype(nr):
             ('PLATEIFU', '<U12'),
             ('PLATE', np.int16),
             ('IFU', np.int16),
+            ('MNGTARG1', np.int32),
+            ('MNGTARG3', np.int32),
+            ('DRP3QUAL', np.int32),
+            ('DAPQUAL', np.int32),
             # Azimuthally binned radial profiles
             ('BINR', float, (nr,)),
             ('AD', float, (nr,)),
@@ -2372,6 +2376,10 @@ def asymdrift_fit_data(galmeta, kin, disk, p0, lb, ub, gas_vel_mask, gas_sig_mas
     adprof['PLATEIFU'] = f'{galmeta.plate}-{galmeta.ifu}'
     adprof['PLATE'] = galmeta.plate
     adprof['IFU'] = galmeta.ifu
+    adprof['MNGTARG1'] = galmeta.mngtarg1
+    adprof['MNGTARG3'] = galmeta.mngtarg3
+    adprof['DRP3QUAL'] = galmeta.drp3qual
+    adprof['DAPQUAL'] = galmeta.dapqual
     adprof['BINR'] = binr
     adprof['AD'] = ad_ewmean
     adprof['AD_SDEV'] = ad_ewsdev

--- a/nirvana/models/multitrace.py
+++ b/nirvana/models/multitrace.py
@@ -1500,9 +1500,12 @@ def asymdrift_fit_maps(kin, disk, rstep, par=None, maj_wedge=30.):
     gv_ivar = np.ma.power(kin[1].bin_moments(kin[0].grid_sb, gv_var_map.filled(0.0), None)[1], -1)
     gv_ivar_map = kin[1].remap(gv_ivar.filled(0.0), mask=ad_mask)
 
-    # Get the binned stellar velocities
+    # Get the binned stellar velocities and update the mapped properties to use
+    # the new mask
     sv = np.ma.MaskedArray(kin[1].vel, mask=ad_mask)
     sv_ivar = np.ma.MaskedArray(kin[1].vel_ivar, mask=ad_mask)
+    sv_map = kin[1].remap(sv)
+    sv_ivar_map = kin[1].remap(sv_ivar)
 
     # Stellar velocity dispersion (squared) data
     sd = np.ma.MaskedArray(kin[1].sig_phys2.copy())

--- a/nirvana/models/multitrace.py
+++ b/nirvana/models/multitrace.py
@@ -1426,7 +1426,7 @@ def asymdrift_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofi
                    marker='o', s=90, alpha=1.0, color='k', zorder=4)
         ax.errorbar(bin_ad_r[ad_indx], bin_ad[ad_indx], yerr=bin_ade[ad_indx],
                     color='k', capsize=0, linestyle='', linewidth=1, alpha=1.0, zorder=2)
-    ax.plot(modelr, np.sqrt(vrotm[0]**2 - vrotm[1]**2), color='k', zorder=5, lw=1)
+    ax.plot(modelr, np.ma.sqrt(vrotm[0]**2 - vrotm[1]**2).filled(0.0), color='k', zorder=5, lw=1)
     if reff_lines is not None:
         for l in reff_lines:
             ax.axvline(x=l, linestyle='--', lw=0.5, zorder=1, color='k')

--- a/nirvana/models/multitrace.py
+++ b/nirvana/models/multitrace.py
@@ -1,0 +1,420 @@
+"""
+Module with a class that fits multiple tracers to a single disk.
+
+.. include common links, assuming primary doc root is up one directory
+.. include:: ../include/links.rst
+"""
+
+import warnings
+
+from IPython import embed
+
+import numpy as np
+from scipy import optimize
+from .util import cov_err
+
+
+class MultiTracerDisk:
+    """
+    Define a class that enables multiple kinematic datasets to be simultaneously
+    fit with the ThinDisk models.
+
+    Args:
+        disk (array-like):
+            The :class:`~nirvana.models.thindisk.ThinDisk` models to use for
+            each dataset; i.e., there must be one disk model per dataset even if
+            the models are identical.  Importantly, these must be separate
+            object instances regardless of whether or not they are identical
+            models.  The :class:`~nirvana.models.thindisk.ThinDisk` classes are
+            used to perform a number of operations that are specific to each
+            dataset that expedite the fit; the results are saved to the
+            internals of the class meaning that there must be one instance per
+            kinematic database.
+        tie_base (array-like, optional):
+            A 5-element vector indicating which geometric projection parameters
+            should tied between the disk models.  The parameters are the
+            dynamical center coordinates (x, y), the position angle, the
+            inclination, and the systemic velocity.
+        tie_disk (array-like, optional):
+            A vector indicating which model-specific parameters should be tied
+            between disks.  Models to be tied must have the same type and the
+            same number of parameters.  The length of this vector must match the
+            number of disk model parameters *excluding* the base parameters.
+    """
+    def __init__(self, disk, tie_base=None, tie_disk=None):
+
+        self.disk = np.atleast_1d(disk)
+        self.ntracer = self.disk.size
+        if self.ntracer == 1:
+            raise ValueError('You are only fitting one dataset.  Use the disk class directly!')
+
+        # Parameter checks
+        if np.any([self.disk[i+1].nbp != self.disk[0].nbp for i in range(self.ntracer-1)]):
+            raise ValueError('All of the disks should have the same number of base parameters.')
+        self.nbp = self.disk[0].nbp
+        self.np = np.sum([d.np for d in self.disk])
+
+        # Setup the ties between base and disk parameters
+        self.tie_base = None
+        self.tie_disk = None
+        self.update_tie_base(tie_base)
+        self.update_tie_disk(tie_disk)
+
+        # Setup the parameters
+        self.par = None
+        self.par_err = None
+        self.global_mask = 0
+        self.fit_status = None
+        self.fit_success = None
+
+        # Workspace
+        self.disk_fom = None
+        self.disk_jac = None
+        self._wrkspc_parslc = None
+        self._wrkspc_ndata = None
+        self._wrkspc_sdata = None
+        self._wrkspc_jac = None
+
+
+    def update_tie_base(self, tie_base):
+        """
+        Setup parameter tying between the base geometric projection parameters.
+        """
+        # Set the internal
+        self.tie_base = np.zeros(self.nbp, dtype=bool) if tie_base is None \
+                            else np.atleast_1d(tie_base)
+        # Check the result
+        if self.tie_base.size != self.nbp:
+            raise ValueError('Number of parameters in base tying vector incorrect!  Expected '
+                             f'{self.nbp}, found {selt.tie_base.size}.')
+        if not np.issubdtype(self.tie_base.dtype, bool):
+            raise TypeError('Base tying vector should hold booleans!')
+        # Reset the tying vectors
+        self.retie()
+
+    @property
+    def can_tie_disks(self):
+        """
+        Check if the disks can be tied.
+
+        Current criteria are:
+
+            - disks must have same class type
+            - disks must have the same number of parameters
+
+        """
+        types = np.array([d.__class__.__name__ for d in self.disk])
+        npar = np.array([d.np for d in self.disk])
+        return np.all(types == types[0]) and np.all(npar == npar[0])
+
+    def update_tie_disk(self, tie_disk):
+        """
+        Setup parameter tying between the disk kinematic parameters
+        """
+        # Set the internal
+        ndp = self.disk[0].np - self.nbp
+        self.tie_disk = np.zeros(ndp, dtype=bool) if tie_disk is None else np.atleast_1d(tie_disk)
+        # Check that the disks *can* be tied
+        if np.any(self.tie_disk) and not self.can_tie_disks:
+            raise ValueError('Disk parameters cannot be tied together!')
+        # Check the tying flags
+        if self.tie_disk.size != ndp:
+            raise ValueError('Number of parameters in kinematics tying vector incorrect!  '
+                             f'Expected {self.disk[0].np - self.nbp}, found {self.tie_disk.size}.')
+        if not np.issubdtype(self.tie_disk.dtype, bool):
+            raise TypeError('Kinematics tying vector should hold booleans!')
+        # Reset the tying vectors
+        self.retie()
+
+    def retie(self):
+        """
+        Construct the tying and untying vectors
+
+        full_par = tied_par[self.untie]
+        tied_par = full_par[self.tie]
+
+        """
+        # Find the starting index for the parameters of each disk
+        s = [0 if i == 0 else np.sum([d.np for d in self.disk[:i]]) for i in range(self.ntracer)]
+
+        # Instatiate as all parameters being untied
+        self.untie = np.arange(self.np)
+
+        # Tie base parameters by replacing parameter indices in disks with the
+        # ones from the first disk.
+        indx = np.where(self.tie_base)[0]
+        if indx.size > 0: 
+            for i in range(self.ntracer-1):
+                self.untie[indx + s[i+1]] = indx
+            
+        # Tie disk parameters by replacing parameter indices in disks with the
+        # ones from the first disk.
+        # NOTE: This works when self.tie_disk is None, so there's no need to test for it
+        indx = np.where(self.tie_disk)[0]
+        if indx.size > 0:
+            for i in range(self.ntracer-1):
+                self.untie[indx + s[i+1] + self.nbp] = indx + self.nbp
+
+        # The tying vector simply uses the unique indices in the untying vector
+        self.tie, self.untie = np.unique(self.untie, return_inverse=True)
+
+        # Set the number of untied, unique parameters
+        self.nup = self.tie.size
+            
+    def guess_par(self, full=False):
+        gp = np.concatenate([d.guess_par() for d in self.disk])
+        return gp if full else gp[self.tie]
+
+    def _init_par(self, p0, fix):
+        """
+        Initialize the parameter vectors.
+
+        This includes the parameter vector itself, :attr:`par`, and the boolean
+        vector selecting the free parameters, :attr:`free`.  This also sets the
+        number of free parameters, :attr:`nfree`.
+
+        Args:
+            p0 (`numpy.ndarray`_):
+                The parameters to use.  The length can be either the total
+                number of parameters (:attr:`np`) or the total number of
+                unique/untied parameters (:attr:`nup`).  If the former, the
+                vector is tied and untied to make sure that the tied parameters
+                are identical.  If None, the parameters are set by
+                :func:`guess_par`.
+            fix (`numpy.ndarray`_):
+                Boolean flags to fix the parameters.  If None or if ``p0`` is
+                None, all parameters are assumed to be free.  If not None, the
+                length *must* match ``p0``.
+        """
+        # If the parameters are not provided, use the defaults
+        if p0 is None:
+            if fix is not None:
+                warnings.warn('To fix parameter, must provide the full set of initial guess '
+                              'parameters.  Ignoring the fixed parameters provided and fitting '
+                              'all parameters.')
+            self.par = self.guess_par()
+            self.free = np.ones(self.nup, dtype=bool)
+            self.nfree = self.nup
+            return
+
+        _p0 = np.atleast_1d(p0)
+        _free = np.ones(_p0.size, dtype=bool) if fix is None else np.logical_not(fix)
+        if _p0.size not in [self.np, self.nup]:
+            raise ValueError('Incorrect number of model parameters.  Must be either '
+                             f'{self.np} (full) or {self.nup} (unique).')
+        if _free.size != _p0.size:
+            raise ValueError('Vector selecting fixed parameters has different length from '
+                             f'parameter vector: {_free.size} instead of {_p0.size}.')
+        self.par = _p0.copy()
+        self.par_err = None
+        self.free = _free.copy()
+        if self.par.size == self.np:
+            self.par = self.par[self.tie]
+            self.free = self.free[self.tie]
+        self.nfree = np.sum(self.free)
+
+    def _set_par(self, par):
+        """
+        Set the full parameter vector, accounting for any fixed and/or tied
+        parameters.
+
+        Args:
+            par (`numpy.ndarray`_, optional):
+                The list of parameters to use. Length must be either the total
+                number of *untied* parameters or the total number of free
+                parameters.
+        """
+        if par.ndim != 1:
+            raise ValueError('Parameter array must be a 1D vector.')
+        if par.size == self.nup:
+            self.par = par.copy()
+            return
+        if par.size != self.nfree:
+            raise ValueError('Must provide {0} or {1} parameters.'.format(self.nup, self.nfree))
+        self.par[self.free] = par.copy()
+
+    def _disk_slice(self, index):
+        """
+        Return the slice selecting parameters for the specified disk from the
+        *full* parameter vector.
+
+        Args:
+            index (:obj:`int`):
+                The index of the disk to select.
+
+        Returns:
+            :obj:`slice`: Slice selected the relevant parameters.
+        """
+        s = 0 if index == 0 else np.sum([d.np for d in self.disk[:index]])
+        return slice(s, s + self.disk[index].np)
+
+    def lsq_fit(self, kin, sb_wgt=False, p0=None, fix=None, lb=None, ub=None, scatter=None,
+                verbose=0, assume_posdef_covar=False, ignore_covar=True, analytic_jac=True,
+                maxiter=5):
+        """
+
+        For all input parameter vectors (``p0``, ``fix``, ``lb``, and ``ub``),
+        the length of all vectors must be the same, but they can be either the
+        total number of parameters (:attr:`np`) or the number of unique (untied)
+        parameters (:attr:`nup`).  If the former, note that only the values of
+        the tied parameters in the first disk will be used.
+                
+        .. warning::
+
+            Currently, this class *does not construct a model of the
+            surface-brightness distribution*.  Instead, any weighting of the
+            model during convolution with the beam profile uses the as-observed
+            surface-brightness distribution, instead of a model of the intrinsic
+            surface brightness distribution.  See ``sb_wgt``.
+
+        Args:
+            kin (array-like):
+                A list of :class:`~nirvana.data.kinematics.Kinematics` objects
+                to fit.  The number of datasets *must* match the number of disks
+                (:attr:`ntracer`).
+            sb_wgt (:obj:`bool`, optional):
+                Flag to use the surface-brightness data provided by each dataset
+                to weight the model when applying the beam-smearing.  **See the
+                warning above**.
+            p0 (`numpy.ndarray`_, optional):
+                The initial parameters for the model.  See function description
+                for the allowed shapes.  If None, the default guess parameters
+                are used; see :func:`guess_par`.
+            fix (`numpy.ndarray`_, optional):
+                A boolean array selecting the parameters that should be fixed
+                during the model fit.  See function description for the allowed
+                shapes.  If None, all parameters are free.
+            lb (`numpy.ndarray`_, optional):
+                The lower bounds for the parameters.  See function description
+                for the allowed shapes.  If None, the defaults are used (see
+                :func:`par_bounds`).
+            ub (`numpy.ndarray`_, optional):
+                The upper bounds for the parameters.  See function description
+                for the allowed shapes.  If None, the defaults are used (see
+                :func:`par_bounds`).
+            scatter (:obj:`float`, array-like, optional):
+                Introduce a fixed intrinsic-scatter term into the model. The 
+                scatter is added in quadrature to all measurement errors in the
+                calculation of the merit function. If no errors are available,
+                this has the effect of renormalizing the unweighted merit
+                function by 1/scatter.  Can be None, which means no intrinsic
+                scatter is added.  The number of provided values can be either:
+
+                    - 1 (i.e., a single float) to apply the same scatter to all
+                      kinematic moments and datasets, 
+                    - the same as the number of disks to apply a separate
+                      scatter to both kinematic moments for each dataset
+                    - twice the number of disks to apply a separate scatter to
+                      all the kinematic moments and datasets.  In this case, the
+                      order is velocity scatter for disk 1, velocity dispersion
+                      scatter for disk 1, velocity scatter for disk 2, etc.
+
+            verbose (:obj:`int`, optional):
+                Verbosity level to pass to `scipy.optimize.least_squares`_.
+            assume_posdef_covar (:obj:`bool`, optional):
+                If any of the :class:`~nirvana.data.kinematics.Kinematics`
+                datasets include covariance matrices, this forces the code to
+                proceed assuming the matrices are positive definite.
+            ignore_covar (:obj:`bool`, optional):
+                If any of the :class:`~nirvana.data.kinematics.Kinematics`
+                datasets include covariance matrices, ignore them and just use
+                the inverse variance.
+            analytic_jac (:obj:`bool`, optional):
+                Use the analytic calculation of the Jacobian matrix during the
+                fit optimization.  If False, the Jacobian is calculated using
+                finite-differencing methods provided by
+                `scipy.optimize.least_squares`_.
+            maxiter (:obj:`int`, optional):
+                The call to `scipy.optimize.least_squares`_ is repeated when it
+                returns best-fit parameters that are *identical* to the input
+                parameters (to within a small tolerance).  This parameter sets
+                the maximum number of times the fit will be repeated.  Set this
+                to 1 to ignore these occurences; ``maxiter`` cannot be None.
+        """
+
+        # Check the length of scatter
+
+        self.kin = np.atleast_1d(kin)
+        if self.kin.size != self.ntracer:
+            raise ValueError('Must provide the same number of kinematic databases as disks '
+                             f'({self.ntracer}).')
+
+        self.disk_fom = [None]*self.ntracer
+        self.disk_jac = [None]*self.ntracer
+
+        self._init_par(p0, fix)
+
+        # Prepare the disks for fitting
+        for i in range(self.ntracer):
+            self.disk[i]._init_model(None, self.kin[i].grid_x, self.kin[i].grid_y,
+                                     self.kin[i].grid_sb if sb_wgt else None,
+                                     self.kin[i].beam_fft, True, None, False)
+            self.disk[i]._init_data(self.kin[i], None if scatter is None else scatter[i],
+                                    assume_posdef_covar, ignore_covar)
+            self.disk_fom[i] = self.disk[i]._get_fom()
+            self.disk_jac[i] = self.disk[i]._get_jac()
+
+        self._wrkspc_parslc = [self._disk_slice(i) for i in range(self.ntracer)]
+        if analytic_jac:
+            # Set the least_squares keywords
+            jac_kwargs = {'jac': self.jac}
+            # Set up the workspace for dealing with tied parameters
+            self._wrkspc_ndata = [np.sum(self.disk[i].vel_gpm) + (0 if self.disk[i].dc is None
+                                    else np.sum(self.disk[i].sig_gpm))
+                                        for i in range(self.ntracer)]
+            self._wrkspc_sdata = np.append([0],np.cumsum(self._wrkspc_ndata)[:-1])
+            self._wrkspc_jac = np.zeros((np.sum(self._wrkspc_ndata), self.nup), dtype=float)
+        else:
+            jac_kwargs = {'diff_step': np.full(self.nup, 0.01, dtype=float)[self.free]}
+
+        # Parameter boundaries
+        lb, ub = self.par_bounds()
+        result = optimize.least_squares(self.fom, self.par[self.free], x_scale='jac', method='trf',
+                                        xtol=1e-12, bounds=(lb[self.free], ub[self.free]), 
+                                        verbose=max(verbose,0), **jac_kwargs)
+        embed()
+        exit()
+
+    def par_bounds(self):
+        """
+        """
+        lb, ub = np.array([list(d.par_bounds()) for d in self.disk]).transpose(1,0,2).reshape(2,-1)
+        return lb[self.tie], ub[self.tie]
+
+    def fom(self, par):
+        """
+        """
+        # Get the tied parameters
+        self._set_par(par)
+        # Untie them to get the full set
+        full_par = self.par[self.untie]
+        return np.concatenate([self.disk_fom[i](full_par[self._wrkspc_parslc[i]]) 
+                                for i in range(self.ntracer)])
+
+    def jac(self, par):
+        """
+        """
+        # Get the tied parameters
+        self._set_par(par)
+        # Untie them to get the full set
+        full_par = self.par[self.untie]
+        _jac = [self.disk_jac[i](full_par[self._wrkspc_parslc[i]]) for i in range(self.ntracer)] 
+        self._wrkspc_jac[...] = 0.
+        assert np.array_equal(self._wrkspc_ndata, [j.shape[0] for j in _jac]), \
+                'Jacobians have incorrect shape!'
+        for i in range(self.ntracer):
+            sec = np.ix_(np.arange(self._wrkspc_ndata[i])+self._wrkspc_sdata[i],
+                         self.untie[self._wrkspc_parslc[i]])
+            self._wrkspc_jac[sec] += _jac[i]
+        return self._wrkspc_jac[:,self.free]
+
+            
+
+        
+
+        
+
+
+
+
+

--- a/nirvana/models/multitrace.py
+++ b/nirvana/models/multitrace.py
@@ -22,6 +22,8 @@ from ..util import plot, fileio
 from . import thindisk
 from . import axisym
 
+#warnings.simplefilter('error', RuntimeWarning)
+
 class MultiTracerDisk:
     """
     Define a class that enables multiple kinematic datasets to be simultaneously

--- a/nirvana/models/multitrace.py
+++ b/nirvana/models/multitrace.py
@@ -1632,7 +1632,7 @@ def asymdrift_fit_maps(kin, disk, rstep, par=None, maj_wedge=30.):
     # NOTE: ad hoc maximum radius is meant to mitigate effect of minor axis
     # points on number radial bins.  This will limit the number of off-axis
     # points included in galaxies with inclinations > 75 deg.
-    maxr = min(4*np.amax(r[ad_indx]), np.amax(r))
+    maxr = min(4*np.amax(r[ad_indx]), np.amax(r)) if np.any(ad_indx) else np.amax(r)
     binr = np.array([rstep/2]) if maxr < rstep/2 else np.arange(rstep/2, maxr, rstep)
     #binr = np.arange(rstep/2, min(4*np.amax(r[ad_indx]), np.amax(r)), rstep)
     binw = np.full(binr.size, rstep, dtype=float)

--- a/nirvana/models/multitrace.py
+++ b/nirvana/models/multitrace.py
@@ -483,13 +483,9 @@ class MultiTracerDisk:
         niter = 0
         while niter < maxiter:
             # Run the optimization
-#            try:
             result = optimize.least_squares(self.fom, p, x_scale='jac', method='trf',
                                             xtol=1e-12, bounds=(_lb[self.free], _ub[self.free]), 
                                             verbose=max(verbose,0), **jac_kwargs)
-#            except Exception as e:
-#                embed()
-#                exit()
             # Attempt to calculate the errors
             try:
                 pe = np.sqrt(np.diag(cov_err(result.jac)))
@@ -873,10 +869,6 @@ def asymdrift_fit_plot(galmeta, kin, disk, par=None, par_err=None, fix=None, ofi
 
     sig_map_lim = growth_lim(np.ma.log10(np.ma.append(sd_map, sd_mod_map)).compressed(), 0.70, 1.05)
     sig_map_lim = atleast_one_decade(np.power(10., sig_map_lim))
-
-#    ados_lim = np.power(10.0, growth_lim(np.ma.log10(np.ma.append(ados_map, adosmod_map).compressed(),
-#                                        0.80, 1.05)))
-#    ados_lim = atleast_one_decade(sig_lim)
 
     ados_lim = growth_lim(np.ma.append(ados_map, ados_mod_map).compressed(), 0.80, 1.05)
 

--- a/nirvana/models/thindisk.py
+++ b/nirvana/models/thindisk.py
@@ -102,7 +102,9 @@ class ThinDiskGlobalBitMask(BitMask):
     prefix = 'GBIT'
     def __init__(self):
         # NOTE: np.array just used for slicing convenience
-        mask_def = np.array([['LOWINC', 'Best fit inclination unreasonably low']])
+        mask_def = np.array([['LOWINC', 'Best fit inclination unreasonably low'],
+                             ['NOMODEL', 'Model not fit or failed'],
+                             ['DIFFMOD', 'Model discrepancy']])
         super().__init__(mask_def[:,0], descr=mask_def[:,1])
 
 

--- a/nirvana/models/thindisk.py
+++ b/nirvana/models/thindisk.py
@@ -598,8 +598,11 @@ class ThinDisk:
                 # Force the matrices to be positive definite
                 print('Forcing vel covar to be pos-def')
                 vel_pd_covar = impose_positive_definite(vel_pd_covar)
-                print('Forcing sig covar to be pos-def')
-                sig_pd_covar = None if self.dc is None else impose_positive_definite(sig_pd_covar)
+                if self.dc is None:
+                    sig_pd_covar = None 
+                else:
+                    print('Forcing sig covar to be pos-def')
+                    sig_pd_covar = impose_positive_definite(sig_pd_covar)
 
             if self.scatter is not None:
                 # A diagonal matrix with only positive values is, by definition,

--- a/nirvana/models/util.py
+++ b/nirvana/models/util.py
@@ -9,9 +9,10 @@ from scipy import linalg, stats
 
 def cov_err(jac):
     """
-    Provided the Jacobian matrix (the derivative of from a least-squares minimization
-    routine, construct the parameter covariance matrix. See e.g.
-    Press et al. 2007, Numerical Recipes, 3rd ed., Section 15.4.2
+    Provided the Jacobian matrix (the derivative of chi-square w.r.t. the model
+    parameters from a least-squares minimization routine, construct the
+    parameter covariance matrix. See e.g.  Press et al. 2007, Numerical Recipes,
+    3rd ed., Section 15.4.2
 
     This is directly pulled from ppxf.capfit.cov_err, but only
     returns the covariance matrix.  See:

--- a/nirvana/scripts/manga_asymdrift.py
+++ b/nirvana/scripts/manga_asymdrift.py
@@ -1,0 +1,302 @@
+"""
+Script that simultaneously fits the ionized gas and stellar kinematic data to
+measure asymmetric drift.
+"""
+import os
+import argparse
+
+from IPython import embed
+
+import numpy as np
+from matplotlib import pyplot
+
+from astropy.io import fits
+
+from ..data import manga
+from ..util import fileio
+from ..models import axisym
+from ..models import multitrace
+
+# TODO: Setup a logger
+
+#import warnings
+#warnings.simplefilter('error', RuntimeWarning)
+
+def parse_args(options=None):
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('plate', type=int, help='MaNGA plate identifier (e.g., 8138)')
+    parser.add_argument('ifu', type=int, help='MaNGA ifu identifier (e.g., 12704)')
+    parser.add_argument('--daptype', default='HYB10-MILESHC-MASTARHC2', type=str,
+                        help='DAP analysis key used to select the data files.  This is needed '
+                             'regardless of whether or not you specify the directory with the '
+                             'data files (using --root).')
+    parser.add_argument('--dr', default='MPL-11', type=str,
+                        help='The MaNGA data release.  This is only used to automatically '
+                             'construct the directory to the MaNGA galaxy data (see also '
+                             '--redux and --analysis), and it will be ignored if the root '
+                             'directory is set directly (using --root).')
+    parser.add_argument('--redux', default=None, type=str,
+                        help='Top-level directory with the MaNGA DRP output.  If not defined and '
+                             'the direct root to the files is also not defined (see --root), '
+                             'this is set by the environmental variable MANGA_SPECTRO_REDUX.')
+    parser.add_argument('--analysis', default=None, type=str,
+                        help='Top-level directory with the MaNGA DAP output.  If not defined and '
+                             'the direct root to the files is also not defined (see --root), '
+                             'this is set by the environmental variable MANGA_SPECTRO_ANALYSIS.')
+    parser.add_argument('--root', default=None, type=str,
+                        help='Path with *all* fits files required for the fit.  This includes ' \
+                             'the DRPall file, the DRP LOGCUBE file, and the DAP MAPS file.  ' \
+                             'The LOGCUBE file is only required if the beam-smearing is ' \
+                             'included in the fit.')
+    parser.add_argument('--verbose', default=0, type=int,
+                        help='Verbosity level.  0=only status output written to terminal; 1=show '
+                             'fit result QA plot; 2=full output.')
+    parser.add_argument('--odir', type=str, default=os.getcwd(), help='Directory for output files')
+    parser.add_argument('--nodisp', dest='disp', default=True, action='store_false',
+                        help='Only fit the velocity field (ignore velocity dispersion)')
+    parser.add_argument('--nopsf', dest='smear', default=True, action='store_false',
+                        help='Ignore the map PSF (i.e., ignore beam-smearing)')
+    parser.add_argument('--covar', default=False, action='store_true',
+                        help='Include the nominal covariance in the fit')
+    parser.add_argument('--fix_cen', default=False, action='store_true',
+                        help='Fix the dynamical center coordinate to the galaxy center')
+    parser.add_argument('--fix_inc', default=False, action='store_true',
+                        help='Fix the inclination to the guess inclination based on the '
+                             'photometric ellipticity')
+    parser.add_argument('--low_inc', default=None, type=float,
+                        help='Best-fitting inclinations below this value are considered fitting '
+                             'errors.  A flag is tripped indicating that the fit resulted in a '
+                             'low inclination, but the actual returned fit fixes the inclination '
+                             'to the photometric estimate (i.e., as if setting --fix_inc).  If '
+                             'None, no lower limit is set.')
+    parser.add_argument('--no_scatter', dest='fit_scatter', default=True, action='store_false',
+                        help='Do not include any intrinsic scatter terms during the model fit.')
+    parser.add_argument('--min_unmasked', default=None, type=int,
+                        help='Minimum number of unmasked spaxels required to continue fit.')
+    parser.add_argument('--sb_fill_sig', default=None, type=float,
+                        help='Fill the surface-brightness map used for constructing the '
+                             'beam-smeared model using an iterative Gaussian smoothing '
+                             'operation.  This parameter both turns this on and sets the size of '
+                             'the circular Gaussian smoothing kernel in spaxels.')
+    parser.add_argument('--coherent', default=False, action='store_true',
+                        help='After the initial rejection of S/N and error limits, find the '
+                             'largest coherent region of adjacent spaxels and only fit that '
+                             'region.')
+    parser.add_argument('--screen', default=False, action='store_true',
+                        help='Indicate that the script is being run behind a screen (used to set '
+                             'matplotlib backend).')
+    parser.add_argument('--skip_plots', default=False, action='store_true',
+                        help='Skip the QA plots and just produce the main output file.')
+
+    parser.add_argument('--gas_rc', default='HyperbolicTangent', type=str,
+                        help='Rotation curve parameterization to use: HyperbolicTangent or PolyEx')
+    parser.add_argument('--gas_dc', default='Exponential', type=str,
+                        help='Dispersion profile parameterization to use: Exponential, ExpBase, '
+                             'or Const.')
+    parser.add_argument('--gas_min_vel_snr', default=None, type=float,
+                        help='Minimum S/N to include for velocity measurements in fit; S/N is '
+                             'calculated as the ratio of the surface brightness to its error')
+    parser.add_argument('--gas_min_sig_snr', default=None, type=float,
+                        help='Minimum S/N to include for dispersion measurements in fit; S/N is '
+                             'calculated as the ratio of the surface brightness to its error')
+    parser.add_argument('--gas_max_vel_err', default=None, type=float,
+                        help='Maximum velocity error to include in fit.')
+    parser.add_argument('--gas_max_sig_err', default=None, type=float,
+                        help='Maximum velocity dispersion error to include in fit '
+                             '(ignored if dispersion not being fit).')
+    parser.add_argument('--gas_max_flux', default=None, type=float,
+                        help='Maximum flux to include in the surface-brightness weighting.')
+    parser.add_argument('--gas_vel_rej', nargs='*', default=[15,10,10,10],
+                        help='The velocity rejection sigma.  Provide 1 or 4 numbers.  If 1 '
+                             'number provided, the same sigma threshold is used for all fit '
+                             'iterations.')
+    parser.add_argument('--gas_sig_rej', nargs='*', default=[15,10,10,10],
+                        help='The dispersion rejection sigma.  Provide 1 or 4 numbers.  If 1 '
+                             'number provided, the same sigma threshold is used for all fit '
+                             'iterations.')
+
+    parser.add_argument('--str_rc', default='HyperbolicTangent', type=str,
+                        help='Rotation curve parameterization to use: HyperbolicTangent or PolyEx')
+    parser.add_argument('--str_dc', default='Exponential', type=str,
+                        help='Dispersion profile parameterization to use: Exponential, ExpBase, '
+                             'or Const.')
+    parser.add_argument('--str_min_vel_snr', default=None, type=float,
+                        help='Minimum S/N to include for velocity measurements in fit; S/N is '
+                             'calculated as the ratio of the surface brightness to its error')
+    parser.add_argument('--str_min_sig_snr', default=None, type=float,
+                        help='Minimum S/N to include for dispersion measurements in fit; S/N is '
+                             'calculated as the ratio of the surface brightness to its error')
+    parser.add_argument('--str_max_vel_err', default=None, type=float,
+                        help='Maximum velocity error to include in fit.')
+    parser.add_argument('--str_max_sig_err', default=None, type=float,
+                        help='Maximum velocity dispersion error to include in fit '
+                             '(ignored if dispersion not being fit).')
+#    parser.add_argument('--str_max_flux', default=None, type=float,
+#                        help='Maximum flux to include in the surface-brightness weighting.')
+    parser.add_argument('--str_vel_rej', nargs='*', default=[15,10,10,10],
+                        help='The velocity rejection sigma.  Provide 1 or 4 numbers.  If 1 '
+                             'number provided, the same sigma threshold is used for all fit '
+                             'iterations.')
+    parser.add_argument('--str_sig_rej', nargs='*', default=[15,10,10,10],
+                        help='The dispersion rejection sigma.  Provide 1 or 4 numbers.  If 1 '
+                             'number provided, the same sigma threshold is used for all fit '
+                             'iterations.')
+    # TODO: Other options:
+    #   - Fit with least-squares vs. dynesty vs. emcee
+    #   - Toggle the surface-brightness weighting
+
+    return parser.parse_args() if options is None else parser.parse_args(options)
+
+
+def main(args):
+
+    # Running the script behind a screen, so switch the matplotlib backend
+    if args.screen:
+        pyplot.switch_backend('agg')
+
+    #---------------------------------------------------------------------------
+    # Setup
+    #  - Check that the output directory exists, and if not create it
+    if not os.path.isdir(args.odir):
+        os.makedirs(args.odir)
+    #  - Set the output root name
+    oroot = f'nirvana-manga-asymdrift-{args.plate}-{args.ifu}'
+
+    #---------------------------------------------------------------------------
+    # Read the metadata and the kinematic data
+    galmeta = manga.MaNGAGlobalPar(args.plate, args.ifu, redux_path=args.redux, dr=args.dr,
+                                   drpall_path=args.root)
+    gas_kin = manga.MaNGAGasKinematics.from_plateifu(args.plate, args.ifu, daptype=args.daptype,
+                                                     dr=args.dr, redux_path=args.redux,
+                                                     cube_path=args.root, image_path=args.root,
+                                                     analysis_path=args.analysis,
+                                                     maps_path=args.root,
+                                                     ignore_psf=not args.smear, covar=args.covar,
+                                                     positive_definite=True,
+                                                     flux_bound=(None, args.gas_max_flux),
+                                                     sb_fill=args.sb_fill_sig)
+    str_kin = manga.MaNGAStellarKinematics.from_plateifu(args.plate, args.ifu,
+                                                         daptype=args.daptype, dr=args.dr,
+                                                         redux_path=args.redux,
+                                                         cube_path=args.root, image_path=args.root,
+                                                         analysis_path=args.analysis,
+                                                         maps_path=args.root,
+                                                         ignore_psf=not args.smear,
+                                                         covar=args.covar, positive_definite=True,
+                                                         sb_fill=args.sb_fill_sig)
+
+    #---------------------------------------------------------------------------
+    # Run the iterative fits separately for the gas and stars
+    gas_disk, gas_p0, gas_fix, gas_vel_mask, gas_sig_mask \
+            = axisym.axisym_iter_fit(galmeta, gas_kin, rctype=args.gas_rc, dctype=args.gas_dc,
+                                     fitdisp=args.disp, ignore_covar=not args.covar,
+                                     max_vel_err=args.gas_max_vel_err,
+                                     max_sig_err=args.gas_max_sig_err,
+                                     min_vel_snr=args.gas_min_vel_snr,
+                                     min_sig_snr=args.gas_min_sig_snr,
+                                     vel_sigma_rej=args.gas_vel_rej,
+                                     sig_sigma_rej=args.gas_sig_rej,
+                                     fix_cen=args.fix_cen, fix_inc=args.fix_inc,
+                                     low_inc=args.low_inc, min_unmasked=args.min_unmasked,
+                                     select_coherent=args.coherent, fit_scatter=args.fit_scatter,
+                                     verbose=args.verbose)
+    gas_only_par = gas_disk.par.copy()
+
+    str_disk, str_p0, str_fix, str_vel_mask, str_sig_mask \
+            = axisym.axisym_iter_fit(galmeta, str_kin, rctype=args.str_rc, dctype=args.str_dc,
+                                     fitdisp=args.disp, ignore_covar=not args.covar,
+                                     max_vel_err=args.str_max_vel_err,
+                                     max_sig_err=args.str_max_sig_err,
+                                     min_vel_snr=args.str_min_vel_snr,
+                                     min_sig_snr=args.str_min_sig_snr,
+                                     vel_sigma_rej=args.str_vel_rej,
+                                     sig_sigma_rej=args.str_sig_rej,
+                                     fix_cen=args.fix_cen, fix_inc=args.fix_inc,
+                                     low_inc=args.low_inc, min_unmasked=args.min_unmasked,
+                                     select_coherent=args.coherent, fit_scatter=args.fit_scatter,
+                                     verbose=args.verbose)
+    str_only_par = str_disk.par.copy()
+
+    #---------------------------------------------------------------------------
+    # Run the combined fit using the independent fits as a starting point
+    disk, p0, fix, gas_vel_mask, gas_sig_mask, str_vel_mask, str_sig_mask \
+            = multitrace.asymdrift_iter_fit(galmeta, gas_kin, str_kin, gas_disk, str_disk, 
+                                            gas_vel_mask=gas_vel_mask, gas_sig_mask=gas_sig_mask,
+                                            str_vel_mask=str_vel_mask, str_sig_mask=str_sig_mask,
+                                            ignore_covar=not args.covar, fix_cen=args.fix_cen,
+                                            fix_inc=args.fix_inc, low_inc=args.low_inc,
+                                            min_unmasked=args.min_unmasked,
+                                            fit_scatter=args.fit_scatter,
+                                            verbose=args.verbose)
+
+    # Create the output data file
+    # - Ensure the best-fitting parameters have been distributed to the disks
+    disk.distribute_par()
+    # - Get the output data for the gas
+    gas_slice = disk.disk_slice(0)
+    gas_hdu = axisym.axisym_fit_data(galmeta, gas_kin, p0[gas_slice], gas_disk,
+                                     gas_vel_mask, gas_sig_mask)
+    # - Get the output data for the stars
+    str_slice = disk.disk_slice(1)
+    str_hdu = axisym.axisym_fit_data(galmeta, str_kin, p0[str_slice], str_disk,
+                                     str_vel_mask, str_sig_mask)
+    # - Combine the data into a single fits file
+    prihdr = gas_hdu[0].header.copy()
+    prihdr.remove('MODELTYP')
+    prihdr.remove('RCMODEL')
+    prihdr.remove('DCMODEL')
+    prihdr['QUAL'] = disk.global_mask
+    resid = disk.fom(disk.par)
+    prihdr['CHI2'] = (np.sum(resid**2), 'Total chi-square')
+    prihdr['RCHI2'] = (prihdr['CHI2']/(resid.size - disk.nfree), 'Total reduced chi-square')
+    for h in gas_hdu[1:]:
+        h.name = 'GAS_'+h.name
+    for h in str_hdu[1:]:
+        h.name = 'STR_'+h.name
+    ofile = os.path.join(args.odir, f'{oroot}.fits.gz')
+    _ofile = ofile[:ofile.rfind('.')]
+    fits.HDUList([fits.PrimaryHDU(header=prihdr)] + gas_hdu[1:] + str_hdu[1:]
+                 ).writeto(_ofile, overwrite=True, checksum=True)
+    fileio.compress_file(_ofile, overwrite=True)
+    os.remove(_ofile)
+
+    if args.skip_plots:
+        return
+
+    # Create the QA plots
+    # - Get the gas fit residuals
+    dv_plot = os.path.join(args.odir, f'{oroot}-Gas-vdist.png')
+    ds_plot = os.path.join(args.odir, f'{oroot}-Gas-sdist.png')
+    gas_disk.reject(vel_plot=dv_plot, sig_plot=ds_plot, plots_only=True) 
+    # - Get the gas asymmetry plots
+    sig_mask=None if gas_disk.dc is None else np.logical_not(gas_disk.sig_gpm)
+    asym_plot = os.path.join(args.odir, f'{oroot}-Gas-asym.png')
+    gas_kin.asymmetry_plot(galmeta=galmeta, xc=gas_disk.par[0], yc=gas_disk.par[1],
+                           pa=gas_disk.par[2], vsys=gas_disk.par[4], fwhm=galmeta.psf_fwhm[1], 
+                           vel_mask=np.logical_not(gas_disk.vel_gpm), sig_mask=sig_mask,
+                           ofile=asym_plot)
+    # - Make the gas fit plots
+    fit_plot = os.path.join(args.odir, f'{oroot}-Gas-fit.png')
+    axisym.axisym_fit_plot(galmeta, gas_kin, gas_disk, fix=fix[gas_slice], ofile=fit_plot)
+
+    # - Get the stellar fit residuals
+    dv_plot = os.path.join(args.odir, f'{oroot}-Stars-vdist.png')
+    ds_plot = os.path.join(args.odir, f'{oroot}-Stars-sdist.png')
+    str_disk.reject(vel_plot=dv_plot, sig_plot=ds_plot, plots_only=True) 
+    # - Get the stellar asymmetry plots
+    sig_mask=None if str_disk.dc is None else np.logical_not(str_disk.sig_gpm)
+    asym_plot = os.path.join(args.odir, f'{oroot}-Stars-asym.png')
+    str_kin.asymmetry_plot(galmeta=galmeta, xc=str_disk.par[0], yc=str_disk.par[1],
+                           pa=str_disk.par[2], vsys=str_disk.par[4], fwhm=galmeta.psf_fwhm[1], 
+                           vel_mask=np.logical_not(str_disk.vel_gpm), sig_mask=sig_mask,
+                           ofile=asym_plot)
+    # - Make the stellar fit plots
+    fit_plot = os.path.join(args.odir, f'{oroot}-Stars-fit.png')
+    axisym.axisym_fit_plot(galmeta, str_kin, str_disk, fix=fix[str_slice], ofile=fit_plot)
+    # - Get the consolidated asymmetric drift plot
+    # Create the final fit plots
+    fit_plot = os.path.join(args.odir, f'{oroot}-asymdrift.png')
+    multitrace.asymdrift_fit_plot(galmeta, [gas_kin, str_kin], disk, ofile=fit_plot)
+
+

--- a/nirvana/scripts/manga_asymdrift.py
+++ b/nirvana/scripts/manga_asymdrift.py
@@ -277,9 +277,9 @@ def main(args):
     sig_mask=None if gas_disk.dc is None else np.logical_not(gas_disk.sig_gpm)
     asym_plot = os.path.join(args.odir, f'{oroot}-Gas-asym.png')
     gas_kin.asymmetry_plot(galmeta=galmeta, xc=gas_disk.par[0], yc=gas_disk.par[1],
-                           pa=gas_disk.par[2], vsys=gas_disk.par[4], fwhm=galmeta.psf_fwhm[1], 
-                           vel_mask=np.logical_not(gas_disk.vel_gpm), sig_mask=sig_mask,
-                           ofile=asym_plot)
+                           pa=gas_disk.par[2], inc=gas_disk.par[3], vsys=gas_disk.par[4],
+                           fwhm=galmeta.psf_fwhm[1], vel_mask=np.logical_not(gas_disk.vel_gpm),
+                           sig_mask=sig_mask, ofile=asym_plot)
     # - Make the gas fit plots
     fit_plot = os.path.join(args.odir, f'{oroot}-Gas-fit.png')
     axisym.axisym_fit_plot(galmeta, gas_kin, gas_disk, fix=fix[gas_slice], ofile=fit_plot)
@@ -296,9 +296,9 @@ def main(args):
     sig_mask=None if str_disk.dc is None else np.logical_not(str_disk.sig_gpm)
     asym_plot = os.path.join(args.odir, f'{oroot}-Stars-asym.png')
     str_kin.asymmetry_plot(galmeta=galmeta, xc=str_disk.par[0], yc=str_disk.par[1],
-                           pa=str_disk.par[2], vsys=str_disk.par[4], fwhm=galmeta.psf_fwhm[1], 
-                           vel_mask=np.logical_not(str_disk.vel_gpm), sig_mask=sig_mask,
-                           ofile=asym_plot)
+                           pa=str_disk.par[2], inc=str_disk.par[3], vsys=str_disk.par[4],
+                           fwhm=galmeta.psf_fwhm[1], vel_mask=np.logical_not(str_disk.vel_gpm),
+                           sig_mask=sig_mask, ofile=asym_plot)
     # - Make the stellar fit plots
     fit_plot = os.path.join(args.odir, f'{oroot}-Stars-fit.png')
     axisym.axisym_fit_plot(galmeta, str_kin, str_disk, fix=fix[str_slice], ofile=fit_plot)

--- a/nirvana/scripts/manga_asymdrift.py
+++ b/nirvana/scripts/manga_asymdrift.py
@@ -188,7 +188,7 @@ def main(args):
 
     #---------------------------------------------------------------------------
     # Run the iterative fits separately for the gas and stars
-    gas_disk, gas_p0, gas_fix, gas_vel_mask, gas_sig_mask \
+    gas_disk, gas_p0, gas_lb, gas_ub, gas_fix, gas_vel_mask, gas_sig_mask \
             = axisym.axisym_iter_fit(galmeta, gas_kin, rctype=args.gas_rc, dctype=args.gas_dc,
                                      fitdisp=args.disp, ignore_covar=not args.covar,
                                      max_vel_err=args.gas_max_vel_err,
@@ -203,7 +203,7 @@ def main(args):
                                      verbose=args.verbose)
     gas_only_par = gas_disk.par.copy()
 
-    str_disk, str_p0, str_fix, str_vel_mask, str_sig_mask \
+    str_disk, str_p0, str_lb, str_ub, str_fix, str_vel_mask, str_sig_mask \
             = axisym.axisym_iter_fit(galmeta, str_kin, rctype=args.str_rc, dctype=args.str_dc,
                                      fitdisp=args.disp, ignore_covar=not args.covar,
                                      max_vel_err=args.str_max_vel_err,
@@ -220,7 +220,7 @@ def main(args):
 
     #---------------------------------------------------------------------------
     # Run the combined fit using the independent fits as a starting point
-    disk, p0, fix, gas_vel_mask, gas_sig_mask, str_vel_mask, str_sig_mask \
+    disk, p0, lb, ub, fix, gas_vel_mask, gas_sig_mask, str_vel_mask, str_sig_mask \
             = multitrace.asymdrift_iter_fit(galmeta, gas_kin, str_kin, gas_disk, str_disk, 
                                             gas_vel_mask=gas_vel_mask, gas_sig_mask=gas_sig_mask,
                                             str_vel_mask=str_vel_mask, str_sig_mask=str_sig_mask,
@@ -235,12 +235,12 @@ def main(args):
     disk.distribute_par()
     # - Get the output data for the gas
     gas_slice = disk.disk_slice(0)
-    gas_hdu = axisym.axisym_fit_data(galmeta, gas_kin, p0[gas_slice], gas_disk,
-                                     gas_vel_mask, gas_sig_mask)
+    gas_hdu = axisym.axisym_fit_data(galmeta, gas_kin, p0[gas_slice], lb[gas_slice], ub[gas_slice],
+                                     gas_disk, gas_vel_mask, gas_sig_mask)
     # - Get the output data for the stars
     str_slice = disk.disk_slice(1)
-    str_hdu = axisym.axisym_fit_data(galmeta, str_kin, p0[str_slice], str_disk,
-                                     str_vel_mask, str_sig_mask)
+    str_hdu = axisym.axisym_fit_data(galmeta, str_kin, p0[str_slice], lb[str_slice], ub[str_slice],
+                                     str_disk, str_vel_mask, str_sig_mask)
     # - Combine the data into a single fits file
     prihdr = gas_hdu[0].header.copy()
     prihdr.remove('MODELTYP')

--- a/nirvana/scripts/manga_asymdrift.py
+++ b/nirvana/scripts/manga_asymdrift.py
@@ -246,6 +246,14 @@ def main(args):
     prihdr.remove('MODELTYP')
     prihdr.remove('RCMODEL')
     prihdr.remove('DCMODEL')
+    prihdr['GMODTYP'] = gas_hdu[0].header['MODELTYP']
+    prihdr['GRCMOD'] = gas_hdu[0].header['RCMODEL']
+    if 'DCMODEL' in gas_hdu[0].header:
+        prihdr['GDCMOD'] = gas_hdu[0].header['DCMODEL']
+    prihdr['SMODTYP'] = str_hdu[0].header['MODELTYP']
+    prihdr['SRCMOD'] = str_hdu[0].header['RCMODEL']
+    if 'DCMODEL' in str_hdu[0].header:
+        prihdr['SDCMOD'] = str_hdu[0].header['DCMODEL']
     prihdr['QUAL'] = disk.global_mask
     resid = disk.fom(disk.par)
     prihdr['CHI2'] = (np.sum(resid**2), 'Total chi-square')

--- a/nirvana/scripts/manga_asymdrift.py
+++ b/nirvana/scripts/manga_asymdrift.py
@@ -265,6 +265,10 @@ def main(args):
         return
 
     # Create the QA plots
+    # - Get the gas mask data
+    mask_plot = os.path.join(args.odir, f'{oroot}-Gas-mask.png')
+    axisym.axisym_fit_plot_masks(galmeta, gas_kin, gas_disk, gas_vel_mask, gas_sig_mask,
+                                 ofile=mask_plot)
     # - Get the gas fit residuals
     dv_plot = os.path.join(args.odir, f'{oroot}-Gas-vdist.png')
     ds_plot = os.path.join(args.odir, f'{oroot}-Gas-sdist.png')
@@ -280,6 +284,10 @@ def main(args):
     fit_plot = os.path.join(args.odir, f'{oroot}-Gas-fit.png')
     axisym.axisym_fit_plot(galmeta, gas_kin, gas_disk, fix=fix[gas_slice], ofile=fit_plot)
 
+    # - Get the stellar mask data
+    mask_plot = os.path.join(args.odir, f'{oroot}-Stars-mask.png')
+    axisym.axisym_fit_plot_masks(galmeta, str_kin, str_disk, str_vel_mask, str_sig_mask,
+                                 ofile=mask_plot)
     # - Get the stellar fit residuals
     dv_plot = os.path.join(args.odir, f'{oroot}-Stars-vdist.png')
     ds_plot = os.path.join(args.odir, f'{oroot}-Stars-sdist.png')
@@ -294,8 +302,8 @@ def main(args):
     # - Make the stellar fit plots
     fit_plot = os.path.join(args.odir, f'{oroot}-Stars-fit.png')
     axisym.axisym_fit_plot(galmeta, str_kin, str_disk, fix=fix[str_slice], ofile=fit_plot)
+
     # - Get the consolidated asymmetric drift plot
-    # Create the final fit plots
     fit_plot = os.path.join(args.odir, f'{oroot}-asymdrift.png')
     multitrace.asymdrift_fit_plot(galmeta, [gas_kin, str_kin], disk, ofile=fit_plot)
 

--- a/nirvana/scripts/manga_asymdrift.py
+++ b/nirvana/scripts/manga_asymdrift.py
@@ -166,7 +166,7 @@ def main(args):
     #---------------------------------------------------------------------------
     # Read the metadata and the kinematic data
     galmeta = manga.MaNGAGlobalPar(args.plate, args.ifu, redux_path=args.redux, dr=args.dr,
-                                   drpall_path=args.root)
+                                   drpall_path=args.root, dapall_path=args.root)
     gas_kin = manga.MaNGAGasKinematics.from_plateifu(args.plate, args.ifu, daptype=args.daptype,
                                                      dr=args.dr, redux_path=args.redux,
                                                      cube_path=args.root, image_path=args.root,

--- a/nirvana/scripts/manga_axisym.py
+++ b/nirvana/scripts/manga_axisym.py
@@ -184,7 +184,7 @@ def main(args):
 
     # Write the output file
     data_file = os.path.join(args.odir, f'{oroot}.fits.gz')
-    axisym.axisym_fit_data(galmeta, kin, p0, disk, data_file, vel_mask, sig_mask)
+    axisym.axisym_fit_data(galmeta, kin, p0, disk, vel_mask, sig_mask, ofile=data_file)
 
     if args.skip_plots:
         return
@@ -192,8 +192,7 @@ def main(args):
     # Plot the final residuals
     dv_plot = os.path.join(args.odir, f'{oroot}-vdist.png')
     ds_plot = os.path.join(args.odir, f'{oroot}-sdist.png')
-    disk.reject(disp=args.disp, ignore_covar=not args.covar, vel_plot=dv_plot, sig_plot=ds_plot,
-                plots_only=True) 
+    disk.reject(vel_plot=dv_plot, sig_plot=ds_plot, plots_only=True) 
 
     # Plot the fit asymmetry
     asym_plot = os.path.join(args.odir, f'{oroot}-asym.png')

--- a/nirvana/scripts/manga_axisym.py
+++ b/nirvana/scripts/manga_axisym.py
@@ -69,9 +69,25 @@ def parse_args(options=None):
                         help='The tracer to fit; must be either Gas or Stars.')
     parser.add_argument('--rc', default='HyperbolicTangent', type=str,
                         help='Rotation curve parameterization to use: HyperbolicTangent or PolyEx')
+#    parser.add_argument('--rc_bounds', default=None, nargs='*', type=str,
+#                        help='Lower and upper bounds to use for each rotation curve parameter.  '
+#                             'Function defaults are used if none provided by the user.  The '
+#                             'number of provided bounds *must* be twice the number of '
+#                             'parameters.  The expected order is: lower bound parameter 1, '
+#                             'upper bound parameter 1, lower bound parameter 2, etc.  Any of the '
+#                             'bounds can be set to None to indicate that the code should use the '
+#                             'function default for that bound.')
     parser.add_argument('--dc', default='Exponential', type=str,
                         help='Dispersion profile parameterization to use: Exponential, ExpBase, '
                              'or Const.')
+#    parser.add_argument('--dc_bounds', default=None, nargs='*', type=str,
+#                        help='Lower and upper bounds to use for each dispersion profile '
+#                             'parameter.  Function defaults are used if none provided by the '
+#                             'user.  The number of provided bounds *must* be twice the number of '
+#                             'parameters.  The expected order is: lower bound parameter 1, '
+#                             'upper bound parameter 1, lower bound parameter 2, etc.  Any of the '
+#                             'bounds can be set to None to indicate that the code should use the '
+#                             'function default for that bound.')
     parser.add_argument('--min_vel_snr', default=None, type=float,
                         help='Minimum S/N to include for velocity measurements in fit; S/N is '
                              'calculated as the ratio of the surface brightness to its error')
@@ -171,7 +187,7 @@ def main(args):
     #---------------------------------------------------------------------------
 
     # Run the iterative fit
-    disk, p0, fix, vel_mask, sig_mask \
+    disk, p0, lb, ub, fix, vel_mask, sig_mask \
             = axisym.axisym_iter_fit(galmeta, kin, rctype=args.rc, dctype=args.dc,
                                      fitdisp=args.disp, ignore_covar=not args.covar,
                                      max_vel_err=args.max_vel_err, max_sig_err=args.max_sig_err,
@@ -184,7 +200,7 @@ def main(args):
 
     # Write the output file
     data_file = os.path.join(args.odir, f'{oroot}.fits.gz')
-    axisym.axisym_fit_data(galmeta, kin, p0, disk, vel_mask, sig_mask, ofile=data_file)
+    axisym.axisym_fit_data(galmeta, kin, p0, lb, ub, disk, vel_mask, sig_mask, ofile=data_file)
 
     if args.skip_plots:
         return

--- a/nirvana/scripts/manga_axisym.py
+++ b/nirvana/scripts/manga_axisym.py
@@ -189,6 +189,10 @@ def main(args):
     if args.skip_plots:
         return
 
+    # Plot the masking data
+    mask_plot = os.path.join(args.odir, f'{oroot}-mask.png')
+    axisym.axisym_fit_plot_masks(galmeta, kin, disk, vel_mask, sig_mask, ofile=mask_plot)
+
     # Plot the final residuals
     dv_plot = os.path.join(args.odir, f'{oroot}-vdist.png')
     ds_plot = os.path.join(args.odir, f'{oroot}-sdist.png')

--- a/nirvana/scripts/manga_axisym.py
+++ b/nirvana/scripts/manga_axisym.py
@@ -217,7 +217,7 @@ def main(args):
     # Plot the fit asymmetry
     asym_plot = os.path.join(args.odir, f'{oroot}-asym.png')
     kin.asymmetry_plot(galmeta=galmeta, xc=disk.par[0], yc=disk.par[1], pa=disk.par[2],
-                       vsys=disk.par[4], fwhm=galmeta.psf_fwhm[1], 
+                       inc=disk.par[3], vsys=disk.par[4], fwhm=galmeta.psf_fwhm[1], 
                        vel_mask=np.logical_not(disk.vel_gpm),
                        sig_mask=None if disk.dc is None else np.logical_not(disk.sig_gpm),
                        ofile=asym_plot)

--- a/nirvana/scripts/manga_axisym.py
+++ b/nirvana/scripts/manga_axisym.py
@@ -183,7 +183,7 @@ def main(args):
 
     # Setup the metadata
     galmeta = manga.MaNGAGlobalPar(args.plate, args.ifu, redux_path=args.redux, dr=args.dr,
-                                   drpall_path=args.root)
+                                   drpall_path=args.root, analysis_path=args.analysis)
     #---------------------------------------------------------------------------
 
     # Run the iterative fit

--- a/nirvana/scripts/manga_axisym.py
+++ b/nirvana/scripts/manga_axisym.py
@@ -183,7 +183,8 @@ def main(args):
 
     # Setup the metadata
     galmeta = manga.MaNGAGlobalPar(args.plate, args.ifu, redux_path=args.redux, dr=args.dr,
-                                   drpall_path=args.root, analysis_path=args.analysis)
+                                   drpall_path=args.root, analysis_path=args.analysis,
+                                   dapall_path=args.root)
     #---------------------------------------------------------------------------
 
     # Run the iterative fit

--- a/nirvana/scripts/manga_axisym_collate.py
+++ b/nirvana/scripts/manga_axisym_collate.py
@@ -194,11 +194,23 @@ def main(args):
         print(f'{i+1}/{nf}', end='\r')
         with fits.open(f) as hdu:
             if args.asymdrift:
-                maxnr = max(maxnr, hdu['GAS_FITMETA'].data['BINR'].shape[1])
-                maxnr = max(maxnr, hdu['STR_FITMETA'].data['BINR'].shape[1])
-                max_adnr = max(max_adnr, hdu['ADPROF'].data['BINR'].shape[1])
+                try:
+                    maxnr = max(maxnr, hdu['GAS_FITMETA'].data['BINR'].shape[1])
+                except:
+                    maxnr = max(maxnr, 1)
+                try:
+                    maxnr = max(maxnr, hdu['STR_FITMETA'].data['BINR'].shape[1])
+                except:
+                    maxnr = max(maxnr, 1)
+                try:
+                    max_adnr = max(max_adnr, hdu['ADPROF'].data['BINR'].shape[1])
+                except:
+                    max_adnr = max(max_adnr, 1)
             else:
-                maxnr = max(maxnr, hdu['FITMETA'].data['BINR'].shape[1])
+                try:
+                    maxnr = max(maxnr, hdu['FITMETA'].data['BINR'].shape[1])
+                except:
+                    maxnr = max(maxnr, 1)
         if args.max_nr is not None:
             maxnr = min(args.max_nr, maxnr)
             max_adnr = min(args.max_nr, max_adnr)

--- a/nirvana/scripts/manga_axisym_collate.py
+++ b/nirvana/scripts/manga_axisym_collate.py
@@ -127,8 +127,11 @@ def main(args):
         dc_keys = ['GDCMOD', 'SDCMOD']
         meta_ext = ['GAS_FITMETA', 'STR_FITMETA']
     else:
-        for i in range(len(plateifu)):
-            plate, ifu = plateifu[i].split('-')
+        # NOTE: Can't loop through plate-ifu numbers in case "full" was
+        # selected.  Need to iterate through files, pull out the plate ifu and
+        # then check if both exist.
+        for f in files:
+            plate, ifu = f.name.split('-')[3:5]
             gas_file = oroot / plate / f'{nirvana_root}-{plate}-{ifu}-Gas.fits.gz'
             str_file = oroot / plate / f'{nirvana_root}-{plate}-{ifu}-Stars.fits.gz'
             if gas_file.exists() and str_file.exists():

--- a/nirvana/scripts/manga_axisym_collate.py
+++ b/nirvana/scripts/manga_axisym_collate.py
@@ -57,6 +57,12 @@ def parse_args(options=None):
     parser.add_argument('-a', '--asymdrift', default=False, action='store_true',
                         help='Default is to find files resulting from nirvana_manga_axisym.  '
                              'This option changes to finding output from nirvana_manga_asymdrift.')
+    parser.add_argument('-r', '--max_nr', default=None, type=int,
+                        help='Maximum number of samples for radial profiles.  If not provided, '
+                             'set by the maximum number of samples in the files to collate.  If '
+                             'provided, code still searches files, but it will use either this '
+                             'number or the maximum number of samples in the files to collate, '
+                             'whichever is smaller.')
 
     return parser.parse_args() if options is None else parser.parse_args(options)
 
@@ -181,6 +187,12 @@ def main(args):
                 max_adnr = max(max_adnr, hdu['ADPROF'].data['BINR'].shape[1])
             else:
                 maxnr = max(maxnr, hdu['FITMETA'].data['BINR'].shape[1])
+        if args.max_nr is not None:
+            maxnr = min(args.max_nr, maxnr)
+            max_adnr = min(args.max_nr, max_adnr)
+        if (args.asymdrift and maxnr == args.max_nr and max_adnr == args.max_nr) \
+                or (not args.asymdrift and maxnr == args.max_nr):
+            break
     print(f'{nf}/{nf}')
 
     # Get the data type for the output tables

--- a/nirvana/scripts/manga_axisym_collate.py
+++ b/nirvana/scripts/manga_axisym_collate.py
@@ -250,19 +250,20 @@ def main(args):
 
         # Save all the metadata regardless of whether or not the galaxy was fit
         gas_metadata['MANGAID'][i] = str_metadata['MANGAID'][i] = galmeta.mangaid
-        ad_metadata['MANGAID'][i] = galmeta.mangaid
         gas_metadata['PLATEIFU'][i] = str_metadata['PLATEIFU'][i] = galmeta.plateifu
-        ad_metadata['PLATEIFU'][i] = galmeta.plateifu
+        if args.asymdrift:
+            ad_metadata['MANGAID'][i] = galmeta.mangaid
+            ad_metadata['PLATEIFU'][i] = galmeta.plateifu
         gas_metadata['PLATE'][i] = str_metadata['PLATE'][i] = galmeta.plate
         gas_metadata['IFU'][i] = str_metadata['IFU'][i] = galmeta.ifu
+        gas_metadata['DRPALLINDX'][i] = str_metadata['DRPALLINDX'][i] = galmeta.drpindx
+        gas_metadata['DAPALLINDX'][i] = str_metadata['DAPALLINDX'][i] = galmeta.dapindx
         gas_metadata['MNGTARG1'][i] = str_metadata['MNGTARG1'][i] = galmeta.mngtarg1
         gas_metadata['MNGTARG3'][i] = str_metadata['MNGTARG3'][i] = galmeta.mngtarg3
         gas_metadata['DRP3QUAL'][i] = str_metadata['DRP3QUAL'][i] = galmeta.drp3qual
         gas_metadata['DAPQUAL'][i] = str_metadata['DAPQUAL'][i] = galmeta.dapqual
         gas_metadata['OBJRA'][i] = str_metadata['OBJRA'][i] = galmeta.ra
         gas_metadata['OBJDEC'][i] = str_metadata['OBJDEC'][i] = galmeta.dec
-        gas_metadata['DRPALLINDX'][i] = str_metadata['DRPALLINDX'][i] = galmeta.drpindx
-        gas_metadata['DAPALLINDX'][i] = str_metadata['DAPALLINDX'][i] = galmeta.dapindx
         gas_metadata['Z'][i] = str_metadata['Z'][i] = galmeta.z
         gas_metadata['ASEC2KPC'][i] = str_metadata['ASEC2KPC'][i] = galmeta.kpc_per_arcsec()
         gas_metadata['PHOTKEY'][i] = str_metadata['PHOTKEY'][i] = galmeta.phot_key

--- a/nirvana/tests/test_asym.py
+++ b/nirvana/tests/test_asym.py
@@ -285,7 +285,7 @@ def test_asymmetry_plot():
             = manga.manga_files_from_plateifu(plate, ifu, cube_path=data_root,
                                               image_path=data_root, maps_path=data_root)
 
-    galmeta = manga.MaNGAGlobalPar(plate, ifu, drpall_path=data_root)
+    galmeta = manga.MaNGAGlobalPar(plate, ifu, drpall_path=data_root, dapall_path=data_root)
     kin = manga.MaNGAGasKinematics(maps_file, cube_file=cube_file, image_file=image_file)
     kin.asymmetry_plot(galmeta=galmeta, xc=xc, yc=yc, pa=pa, vsys=vsys, fwhm=galmeta.psf_fwhm[1],
                        ofile=ofile)

--- a/nirvana/tests/test_bisym.py
+++ b/nirvana/tests/test_bisym.py
@@ -72,5 +72,5 @@ def test_lsq_nopsf():
 #    assert 243. < disk.par[5] < 245., 'Projected rotation changed'
 
 
-test_lsq_nopsf()
+#test_lsq_nopsf()
 

--- a/nirvana/tests/test_manga.py
+++ b/nirvana/tests/test_manga.py
@@ -11,7 +11,7 @@ from astropy import convolution
 from nirvana.data import manga
 from nirvana.data import util
 from nirvana.tests.util import remote_data_file, requires_remote
-from nirvana.tests.util import drp_test_version, dap_test_daptype
+from nirvana.tests.util import drp_test_version, dap_test_version, dap_test_daptype
 
 # TODO: Add a test for remapping
 
@@ -122,7 +122,8 @@ def test_inv_covar():
 @requires_remote
 def test_meta():
     drpall_file = remote_data_file(f'drpall-{drp_test_version}.fits')
-    meta = manga.MaNGAGlobalPar(8138, 12704, drpall_file=drpall_file)
+    dapall_file = remote_data_file(f'dapall-{drp_test_version}-{dap_test_version}.fits')
+    meta = manga.MaNGAGlobalPar(8138, 12704, drpall_file=drpall_file, dapall_file=dapall_file)
 
 
 def test_versions():

--- a/nirvana/tests/test_multi.py
+++ b/nirvana/tests/test_multi.py
@@ -1,0 +1,47 @@
+
+from IPython import embed
+
+import numpy
+
+from matplotlib import pyplot
+
+from scipy import stats, special
+from nirvana.data import manga
+from nirvana.data import util
+from nirvana.data import scatter
+from nirvana.tests.util import remote_data_file, requires_remote
+from nirvana.models.oned import HyperbolicTangent, Exponential
+from nirvana.models.axisym import AxisymmetricDisk
+from nirvana.models.bisym import BisymmetricDisk
+from nirvana.models.beam import gauss2d_kernel, ConvolveFFTW
+from nirvana.models.multitrace import MultiTracerDisk
+
+
+@requires_remote
+def test_lsq_nopsf():
+
+    stellar_disk = AxisymmetricDisk(rc=HyperbolicTangent(), dc=Exponential())
+    gas_disk = AxisymmetricDisk(rc=HyperbolicTangent(), dc=Exponential())
+
+    # This ties the center coordinates and the inclination, but leaves the
+    # position angle and the systemic velocity to be free
+    disk = MultiTracerDisk([gas_disk, stellar_disk], tie_base=[True, True, False, True, False])
+                           #, tie_disk=[True, False, False, False])
+
+    p0 = disk.guess_par()
+    fix = numpy.zeros(p0.size, dtype=bool)
+    # Fix the center
+    fix[0:2] = True
+
+    # Read the data to fit
+    data_root = remote_data_file()
+    stellar_kin = manga.MaNGAStellarKinematics.from_plateifu(8138, 12704, cube_path=data_root,
+                                                     maps_path=data_root)
+
+    gas_kin = manga.MaNGAGasKinematics.from_plateifu(8138, 12704, cube_path=data_root,
+                                                     maps_path=data_root)
+
+    disk.lsq_fit([gas_kin, stellar_kin], sb_wgt=True, p0=p0, fix=fix, verbose=2)
+
+test_lsq_nopsf()
+

--- a/nirvana/tests/test_multi.py
+++ b/nirvana/tests/test_multi.py
@@ -43,5 +43,4 @@ def test_lsq_nopsf():
 
     disk.lsq_fit([gas_kin, stellar_kin], sb_wgt=True, p0=p0, fix=fix, verbose=2)
 
-test_lsq_nopsf()
 

--- a/nirvana/tests/test_scripts.py
+++ b/nirvana/tests/test_scripts.py
@@ -21,6 +21,14 @@ def test_manga_axisym():
                                     '--max_vel_err', '100', '--max_sig_err', '100',
                                     '--min_unmasked', '10', '--coherent', '--skip_plots'])
     manga_axisym.main(args)
+#    embed()
+#
+#    args = manga_axisym.parse_args(['8138', '12704', '--root', remote_data_file(), '--odir', odir,
+#                                    '-t', 'Gas', '--min_vel_snr', '5', '--min_sig_snr', '5',
+#                                    '--max_vel_err', '100', '--max_sig_err', '100',
+#                                    '--min_unmasked', '10', '--coherent', '--covar', '--skip_plots'])
+#    manga_axisym.main(args)
+#    exit()
 
     main_output_file = os.path.join(odir, 'nirvana-manga-axisym-8138-12704-Gas.fits.gz')
     assert os.path.isfile(main_output_file), 'Output file not created.'
@@ -31,6 +39,7 @@ def test_manga_axisym():
 
     shutil.rmtree(odir)
 
+#test_manga_axisym()
 
 @requires_remote
 def test_manga_asymdrift():

--- a/nirvana/tests/test_scripts.py
+++ b/nirvana/tests/test_scripts.py
@@ -42,20 +42,18 @@ def test_manga_asymdrift():
                                        '--gas_max_vel_err', '100', '--gas_max_sig_err', '100',
                                        '--str_min_vel_snr', '5', '--str_min_sig_snr', '10',
                                        '--str_max_vel_err', '100', '--str_max_sig_err', '100',
-                                       '--min_unmasked', '10', '--coherent']) #, '--skip_plots'])
+                                       '--min_unmasked', '10', '--coherent', '--skip_plots'])
+                                       #]) #, '--verbose', '2'])
     manga_asymdrift.main(args)
 
-    embed()
-    exit()
-
-    main_output_file = os.path.join(odir, 'nirvana-manga-asymdrift-8138-12704-Gas.fits.gz')
+    main_output_file = os.path.join(odir, 'nirvana-manga-asymdrift-8138-12704.fits.gz')
     assert os.path.isfile(main_output_file), 'Output file not created.'
 
     with fits.open(main_output_file) as hdu:
-        assert len(hdu) == 24, 'Data model changed'
-        assert hdu['FITMETA'].data['RCHI2'] < 1.1, 'Fit dramatically changed'
+        assert len(hdu) == 47, 'Data model changed'
+        assert hdu['GAS_FITMETA'].data['RCHI2'] < 1.1, 'Fit dramatically changed'
+        assert hdu['STR_FITMETA'].data['RCHI2'] < 1.1, 'Fit dramatically changed'
+        assert hdu[0].header['RCHI2'] < 1.1, 'Fit dramatically changed'
 
     shutil.rmtree(odir)
-
-test_manga_asymdrift()
 

--- a/nirvana/tests/test_scripts.py
+++ b/nirvana/tests/test_scripts.py
@@ -6,7 +6,7 @@ from IPython import embed
 
 from astropy.io import fits
 
-from nirvana.scripts import manga_axisym
+from nirvana.scripts import manga_axisym, manga_asymdrift
 from nirvana.tests.util import remote_data_file, requires_remote
 
 @requires_remote
@@ -29,4 +29,33 @@ def test_manga_axisym():
         assert hdu['FITMETA'].data['RCHI2'] < 1.1, 'Fit dramatically changed'
 
     shutil.rmtree(odir)
+
+@requires_remote
+def test_manga_asymdrift():
+    odir = remote_data_file('tests/8138')
+    if os.path.isdir(odir):
+        shutil.rmtree(odir)
+
+    args = manga_asymdrift.parse_args(['8138', '12704', '--root', remote_data_file(),
+                                       '--odir', odir,
+                                       '--gas_min_vel_snr', '5', '--gas_min_sig_snr', '5',
+                                       '--gas_max_vel_err', '100', '--gas_max_sig_err', '100',
+                                       '--str_min_vel_snr', '5', '--str_min_sig_snr', '10',
+                                       '--str_max_vel_err', '100', '--str_max_sig_err', '100',
+                                       '--min_unmasked', '10', '--coherent']) #, '--skip_plots'])
+    manga_asymdrift.main(args)
+
+    embed()
+    exit()
+
+    main_output_file = os.path.join(odir, 'nirvana-manga-asymdrift-8138-12704-Gas.fits.gz')
+    assert os.path.isfile(main_output_file), 'Output file not created.'
+
+    with fits.open(main_output_file) as hdu:
+        assert len(hdu) == 24, 'Data model changed'
+        assert hdu['FITMETA'].data['RCHI2'] < 1.1, 'Fit dramatically changed'
+
+    shutil.rmtree(odir)
+
+test_manga_asymdrift()
 

--- a/nirvana/tests/test_scripts.py
+++ b/nirvana/tests/test_scripts.py
@@ -9,6 +9,7 @@ from astropy.io import fits
 from nirvana.scripts import manga_axisym, manga_asymdrift
 from nirvana.tests.util import remote_data_file, requires_remote
 
+
 @requires_remote
 def test_manga_axisym():
     odir = remote_data_file('tests/8138')
@@ -29,6 +30,7 @@ def test_manga_axisym():
         assert hdu['FITMETA'].data['RCHI2'] < 1.1, 'Fit dramatically changed'
 
     shutil.rmtree(odir)
+
 
 @requires_remote
 def test_manga_asymdrift():

--- a/nirvana/tests/test_scripts.py
+++ b/nirvana/tests/test_scripts.py
@@ -39,7 +39,6 @@ def test_manga_axisym():
 
     shutil.rmtree(odir)
 
-#test_manga_axisym()
 
 @requires_remote
 def test_manga_asymdrift():
@@ -61,10 +60,11 @@ def test_manga_asymdrift():
     assert os.path.isfile(main_output_file), 'Output file not created.'
 
     with fits.open(main_output_file) as hdu:
-        assert len(hdu) == 47, 'Data model changed'
+        assert len(hdu) == 66, 'Data model changed'
         assert hdu['GAS_FITMETA'].data['RCHI2'] < 1.1, 'Fit dramatically changed'
         assert hdu['STR_FITMETA'].data['RCHI2'] < 1.1, 'Fit dramatically changed'
         assert hdu[0].header['RCHI2'] < 1.1, 'Fit dramatically changed'
 
     shutil.rmtree(odir)
+
 

--- a/nirvana/tests/test_scripts.py
+++ b/nirvana/tests/test_scripts.py
@@ -21,13 +21,13 @@ def test_manga_axisym():
                                     '--max_vel_err', '100', '--max_sig_err', '100',
                                     '--min_unmasked', '10', '--coherent', '--skip_plots'])
     manga_axisym.main(args)
-#    embed()
-#
+
 #    args = manga_axisym.parse_args(['8138', '12704', '--root', remote_data_file(), '--odir', odir,
 #                                    '-t', 'Gas', '--min_vel_snr', '5', '--min_sig_snr', '5',
 #                                    '--max_vel_err', '100', '--max_sig_err', '100',
 #                                    '--min_unmasked', '10', '--coherent', '--covar', '--skip_plots'])
 #    manga_axisym.main(args)
+#    embed()
 #    exit()
 
     main_output_file = os.path.join(odir, 'nirvana-manga-axisym-8138-12704-Gas.fits.gz')

--- a/nirvana/util/bitmask.py
+++ b/nirvana/util/bitmask.py
@@ -18,6 +18,8 @@ import os
 import textwrap
 from configparser import ConfigParser
 
+from IPython import embed
+
 import numpy
 
 from pydl.pydlutils.yanny import yanny
@@ -78,10 +80,6 @@ class BitMask:
         if _descr is not None:
             for i in range(len(_descr)):
                 _descr[i] = _descr[i].strip()
-
-#        from IPython import embed
-#        embed()
-
         if _descr is not None:
             if not all([isinstance(d, str) for d in _descr]):
                 raise TypeError('Input descriptions must have string type.')
@@ -539,7 +537,7 @@ class BitMask:
         if prefix is None:
             prefix = self.prefix
         maxbit = max(list(self.bits.values()))
-        ndig = int(numpy.log10(maxbit))+1 
+        ndig = 1 if maxbit == 0 else int(numpy.log10(maxbit))+1 
         for key, value in sorted(self.bits.items(), key=lambda x:(x[1],x[0])):
             if key == 'NULL':
                 continue

--- a/nirvana/util/fileio.py
+++ b/nirvana/util/fileio.py
@@ -168,10 +168,10 @@ def initialize_primary_header(galmeta=None):
     if galmeta is not None:
         hdr['MANGADR'] = (galmeta.dr, 'MaNGA Data Release')
         hdr['MANGAID'] = (galmeta.mangaid, 'MaNGA ID number')
-        hdr['PLATEIFU'] = (f'{galmeta.plate}-{galmeta.ifu}', 'MaNGA observation plate and IFU')
+        hdr['PLATEIFU'] = (galmeta.plateifu, 'MaNGA observation plate and IFU')
 
     # Add versioning
-    hdr['VERSPY'] = ('.'.join([ str(v) for v in sys.version_info[:3]]), 'Python version')
+    hdr['VERSPY'] = ('.'.join([str(v) for v in sys.version_info[:3]]), 'Python version')
     hdr['VERSNP'] = (np.__version__, 'Numpy version')
     hdr['VERSSCI'] = (scipy.__version__, 'Scipy version')
     hdr['VERSAST'] = (astropy.__version__, 'Astropy version')

--- a/nirvana/util/fileio.py
+++ b/nirvana/util/fileio.py
@@ -172,10 +172,22 @@ def add_wcs(hdr, kin):
 
 # TODO: Assumes uncertainties are provided as inverse variances...
 def finalize_header(hdr, ext, bunit=None, hduclas2='DATA', err=False, qual=False, bm=None,
-                    bit_type=None, prepend=True):
+                    bit_type=None, prepend=True, channel_names=None, channel_units=None):
 
     # Don't change the input header
     _hdr = hdr.copy()
+
+    if channel_names is not None:
+        nchannels = len(channel_names)
+        ndig = int(np.log10(nchannels))+1
+        if channel_units is not None and len(channel_units) != nchannels:
+            raise ValueError('Length of column names and units are not the same.')
+
+        for i in range(nchannels):
+            _hdr['C'+f'{i+1}'.zfill(ndig)] = (channel_names[i], f'Data in channel {i+1}')
+            if channel_units is not None:
+                _hdr['U'+f'{i+1}'.zfill(ndig)] \
+                            = (channel_units[i], f'Units of data in channel {i+1}')
 
     # Add the units
     if bunit is not None:

--- a/nirvana/util/fileio.py
+++ b/nirvana/util/fileio.py
@@ -97,26 +97,42 @@ def rec_to_fits_col_dim(rec_element):
     return None if len(rec_element[0].shape) <= 1 else str(rec_element[0].shape[::-1])
 
 
-def compress_file(ifile, overwrite=False):
+def compress_file(ifile, overwrite=False, rm_original=False):
     """
-    Compress a file using gzip.  The output file has the same name as
-    the input file with '.gz' appended.
+    Compress a file using gzip.
 
-    Any existing file will be overwritten if overwrite is true.
+    The function creates *a new file* with the same name as the input file,
+    except that ``'.gz'`` is appended.  The original file can be removed using
+    ``rm_original``.
 
-    An error is raised if the input file name already has '.gz' appended
-    to the end.
+    Args:
+        ifile (:obj:`str`):
+            Output file to write.  Should *not* aleady have a '.gz' suffix.
+        overwrite (:obj:`bool`, optional):
+            Overwrite any existing file.
+        rm_original (:obj:`bool`, optional):
+            Remove the original (uncompressed) file.
+
+    Raises:
+        ValueError:
+            Raised if the file name already has the suffix ``'.gz'``.
+        FileExistsError:
+            Raised if the compressed file already exists and ``overwrite`` is
+            False.
     """
     if ifile.split('.')[-1] == 'gz':
         raise ValueError(f'{ifile} appears to already have been compressed!')
 
-    ofile = f'{ifile}.gz'
+    ofile = '{0}.gz'.format(ifile)
     if os.path.isfile(ofile) and not overwrite:
         raise FileExistsError(f'File already exists: {ofile}.\nTo overwrite, set overwrite=True.')
 
     with open(ifile, 'rb') as f_in:
         with gzip.open(ofile, 'wb') as f_out:
             shutil.copyfileobj(f_in, f_out)
+
+    if rm_original:
+        os.remove(ifile)
 
 
 def create_symlink(ofile, symlink_dir, relative_symlink=True, overwrite=False, quiet=False):


### PR DESCRIPTION
Major updates to allow for simultaneous fitting of gas and stars, used to measure asymmetric drift.  Changes include:

- Added `MultiTracerDisk` class that enables one to simultaneously fit multiple
   kinematic tracers of the same disk.  This is currently only used for
   simultaneous fitting of gas and stellar kinematics, particularly useful for
   measuring asymmetric drift
 - Improve asymmetry measures and plots
 - Construct radial profiles with and without beam-smearing "corrections"
 - Change main axisymmetric fit diagnostic plots to include effects of
   beam-smearing on velocity and velocity dispersion fields (instead of showing
   the intrinsic fields)
 - Add a plot that shows the different masking steps
 - For MaNGA:
    - Improve download functionality
    - Change to using redshift in DAPall file, instead of DRPall file to include
      corrections made in the former (see the mangadap redshift fix file)
    - Include targeting and data-quality bits and row indices in DRPall/DAPall
      files in the main Kinematics classes
    - Enable consolidated output databases for both independent fits and
      combined (stars+gas) fits
    - Fix download_test_data.py script to download public data from DR17